### PR TITLE
Expose get_var_address in XMI

### DIFF
--- a/examples/run_advanced.py
+++ b/examples/run_advanced.py
@@ -1,6 +1,5 @@
 import os
 import matplotlib.pyplot as plt
-
 from xmipy import XmiWrapper
 
 # for debugging
@@ -12,7 +11,7 @@ if debug_native:
         exit(0)
 
 # defaults
-mf6_dll = r"d:\checkouts\modflow6-mjr\bin\libmf6d.dll"
+mf6_dll = r"d:\checkouts\modflow6-mjr\bin\libmf6.dll"
 mf6_config_file = r"d:\Data\Models\mf6\multilayer\mfsim.nam"
 
 # load the wrapper and cd to model dir
@@ -27,16 +26,22 @@ mf6 = XmiWrapper(mf6_dll)
 mf6.initialize(mf6_config_file)
 
 # get some 'pointers' to MF6 internal data
-head = mf6.get_value_ptr("SLN_1/X")
-shape = mf6.get_var_shape("FLOW15 RCH-1/BOUND")
-recharge = mf6.get_value_ptr("FLOW15 RCH-1/BOUND")
-sc2 = mf6.get_value_ptr("FLOW15 STO/SC2")
-N_sc2 = mf6.get_var_shape("FLOW15 STO/SC2")
-update_sc2 = mf6.get_value_ptr("FLOW15 STO/IRESETSC2")
-max_iter_arr = mf6.get_value_ptr("SLN_1/MXITER")
+head_tag = mf6.get_var_address("X", "SLN_1")
+head = mf6.get_value_ptr(head_tag)
+rch_tag = mf6.get_var_address("BOUND", "FLOW15", "RCH-1")
+shape = mf6.get_var_shape(rch_tag)
+recharge = mf6.get_value_ptr(rch_tag)
+sc2_tag = mf6.get_var_address("SC2", "FLOW15", "STO")
+sc2 = mf6.get_value_ptr(sc2_tag)
+N_sc2 = mf6.get_var_shape(sc2_tag)
+sc2reset_tag = mf6.get_var_address("IRESETSC2", "FLOW15", "STO")
+update_sc2 = mf6.get_value_ptr(sc2reset_tag)
+mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
+max_iter_arr = mf6.get_value_ptr(mxit_tag)
 
 # at some point we would need access to this stuff as well...
-nodeuser = mf6.get_value_ptr("FLOW15 DIS/NODEUSER")
+nodeuser_tag = mf6.get_var_address("NODEUSER", "FLOW15", "DIS")
+nodeuser = mf6.get_value_ptr(nodeuser_tag)
 
 # time loopy
 start_time = mf6.get_start_time()

--- a/examples/run_anisotropy.py
+++ b/examples/run_anisotropy.py
@@ -26,9 +26,13 @@ mf6 = XmiWrapper(mf6_dll)
 mf6.initialize(mf6_config_file)
 
 # get some 'pointers' to MF6 internal data
-head = mf6.get_value_ptr("TESTJE/X")
-spdis = mf6.get_value_ptr("TESTJE NPF/SPDIS")
-init_head = mf6.get_value_ptr("TESTJE IC/STRT")
+head_tag = mf6.get_var_address("X", "TESTJE")
+head = mf6.get_value_ptr(head_tag)
+spdis_tag = mf6.get_var_address("SPDIS", "TESTJE", "NPF")
+spdis = mf6.get_value_ptr(spdis_tag)
+init_head_tag = mf6.get_var_address("STRT", "TESTJE", "IC")
+init_head = mf6.get_value_ptr(init_head_tag)
+
 rndm_head = 1.0 + np.random.rand(10, 10)
 init_head = rndm_head
 

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -61,7 +61,10 @@ class XmiWrapper(Xmi):
             # Can we get it to work without this flag?
             self.lib = CDLL(lib_path, winmode=0x08)
 
-        self.MAXSTRLEN = self.get_constant_int("MAXSTRLEN")
+        self.LENVARTYPE = self.get_constant_int("BMI_LENVARTYPE")
+        self.LENGRIDTYPE = self.get_constant_int("BMI_LENGRIDTYPE")
+        self.LENVARADDRESS = self.get_constant_int("BMI_LENVARADDRESS")
+
         self.working_directory = working_directory
         self._state = State.UNINITIALIZED
         self.timing = timing
@@ -182,7 +185,7 @@ class XmiWrapper(Xmi):
         return grid_id.value
 
     def get_var_type(self, name: str) -> str:
-        var_type = create_string_buffer(self.MAXSTRLEN)
+        var_type = create_string_buffer(self.LENVARTYPE)
         self.execute_function(
             self.lib.get_var_type,
             c_char_p(name.encode()),
@@ -352,7 +355,7 @@ class XmiWrapper(Xmi):
         raise NotImplementedError
 
     def get_grid_type(self, grid: int) -> str:
-        grid_type = create_string_buffer(self.MAXSTRLEN)
+        grid_type = create_string_buffer(self.LENVARTYPE)
         c_grid = c_int(grid)
         self.execute_function(
             self.lib.get_grid_type,
@@ -484,6 +487,20 @@ class XmiWrapper(Xmi):
         os.chdir(self.working_directory)
         self.execute_function(self.lib.finalize_solve, byref(cid))
         os.chdir(previous_directory)
+
+    def get_var_address(self, var_name: str, component_name: str,
+                        subcomponent_name="") -> str:
+        var_address = create_string_buffer(self.LENVARADDRESS)
+        self.execute_function(self.lib.get_var_address,
+                                c_char_p(component_name.encode()),
+                                c_char_p(subcomponent_name.encode()),
+                                c_char_p(var_name.encode()),
+                                byref(var_address))
+
+        return var_address.value.decode()
+
+
+
 
     def execute_function(self, function, *args, detail=""):
         """

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -355,7 +355,7 @@ class XmiWrapper(Xmi):
         raise NotImplementedError
 
     def get_grid_type(self, grid: int) -> str:
-        grid_type = create_string_buffer(self.LENVARTYPE)
+        grid_type = create_string_buffer(self.LENGRIDTYPE)
         c_grid = c_int(grid)
         self.execute_function(
             self.lib.get_grid_type,

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -492,15 +492,12 @@ class XmiWrapper(Xmi):
                         subcomponent_name="") -> str:
         var_address = create_string_buffer(self.LENVARADDRESS)
         self.execute_function(self.lib.get_var_address,
-                                c_char_p(component_name.encode()),
-                                c_char_p(subcomponent_name.encode()),
-                                c_char_p(var_name.encode()),
-                                byref(var_address))
+                              c_char_p(component_name.encode()),
+                              c_char_p(subcomponent_name.encode()),
+                              c_char_p(var_name.encode()),
+                              byref(var_address))
 
         return var_address.value.decode()
-
-
-
 
     def execute_function(self, function, *args, detail=""):
         """


### PR DESCRIPTION
The latest MF6 dll now has a get_var_address to uniquely create the variable address string with the same logic as used by the internal memory manager. This is now wrapped in XMI and the examples are updated accordingly

fixes #IMOD6-324