### PR TITLE
Replace chdir with contextmanager

### DIFF
--- a/xmipy/utils.py
+++ b/xmipy/utils.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+import os
+
+
+@contextmanager
+def cd(newdir):
+    prevdir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)


### PR DESCRIPTION
This prevents permanently changed cwd in case of a thrown exception
Note: contextmanager turned out to be more suitable than decorators

Please see https://issuetracker.deltares.nl/browse/IMOD6-333