### PR TITLE
Add test for grid_rank

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ class FlopyDis:
     model_name: str
     nrow: int
     ncol: int
+    nlay: int
     stress_period_data: List[Any]
 
 
@@ -54,6 +55,7 @@ def flopy_dis(tmp_path, modflow_lib_path):
         model_name="TEST_MODEL_DIS",
         nrow=9,
         ncol=10,
+        nlay=1,
         stress_period_data=[[(0, 2, 0), 1.0], [(0, 6, 8), 0.0]],
     )
     flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=2, perioddata=flopy_dis.tdis_rc)

--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -430,6 +430,30 @@ def test_set_value_at_indices(flopy_dis, modflow_lib_path):
         mf6.set_value_at_indices("", np.zeros((1, 1)), np.zeros((1, 1)))
 
 
+def test_get_grid_rank(flopy_dis, modflow_lib_path):
+    """Tests if the the grid rank can be extracted"""
+
+    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+
+    # Write output to screen:
+    mf6.set_int("ISTDOUTTOFILE", 0)
+
+    try:
+        mf6.initialize()
+
+        prescribed_grid_rank = flopy_dis.rank
+
+        # Getting the grid id from the model, requires specifying one variable
+        k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
+        grid_id = mf6.get_var_grid(k11_tag)
+
+        actual_grid_rank = mf6.get_grid_rank(grid_id)
+
+        assert prescribed_grid_rank == actual_grid_rank
+    finally:
+        mf6.finalize()
+
+
 def test_get_grid_size(flopy_dis, modflow_lib_path):
     """Tests if the the grid size can be extracted"""
 

--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -441,7 +441,10 @@ def test_get_grid_rank(flopy_dis, modflow_lib_path):
     try:
         mf6.initialize()
 
-        prescribed_grid_rank = flopy_dis.rank
+        if flopy_dis.nlay == 1:
+            prescribed_grid_rank = 2
+        else:
+            prescribed_grid_rank = 3
 
         # Getting the grid id from the model, requires specifying one variable
         k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")


### PR DESCRIPTION
I've missed one test and I get immediately punished.
After https://github.com/MODFLOW-USGS/modflow6/pull/567 has been merged and the nightly build is finished, a re-run should be enough to make the tests work.