### PR TITLE
- add test for side effect in setting storage with BMI

### DIFF
--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -1,5 +1,4 @@
 import math
-import os
 
 import numpy as np
 import pytest
@@ -442,6 +441,50 @@ def test_set_value(flopy_dis, modflow_lib_path):
             arr_int = np.zeros(shape=(1,), dtype=np.int32)
             mf6.set_value(mxit_tag, arr_int)
 
+    finally:
+        mf6.finalize()
+
+
+def test_set_value_sideeffect(flopy_gwf_sto, modflow_lib_path):
+    mf6 = XmiWrapper(
+        lib_path=modflow_lib_path, working_directory=flopy_gwf_sto.sim_path
+    )
+
+    # Write output to screen:
+    mf6.set_int("ISTDOUTTOFILE", 0)
+
+    try:
+        # Initialize
+        mf6.initialize()
+
+        area = 100.0
+        sc1_tag = next(var for var in mf6.get_input_var_names() if var.endswith("/SC1"))
+        sc1 = mf6.get_value_ptr(sc1_tag)
+        sc2_tag = next(var for var in mf6.get_input_var_names() if var.endswith("/SC2"))
+        sc2 = mf6.get_value_ptr(sc2_tag)
+
+        orig_sc1 = sc1.copy()
+        new_sc1 = sc1 / area
+
+        # sc1,sc2 cannot be set until sto_rp() has been called,
+        # this happens inside prepare_time_step():
+        # dt = 0.0
+        # mf6.prepare_time_step(dt)
+
+        # setting storage should trigger the conversion again,
+        # such that the sc1 values end up the same:
+        mf6.set_value(sc1_tag, new_sc1)
+        assert np.array_equal(sc1, orig_sc1)
+
+        # same for SC2
+        orig_sc2 = sc2.copy()
+        new_sc2 = sc2 / area
+        mf6.set_value(sc2_tag, new_sc2)
+        assert np.array_equal(sc2, orig_sc2)
+
+        # mf6.do_time_step()
+        # mf6.finalize_time_step()
+        mf6.update()
     finally:
         mf6.finalize()
 

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -290,7 +290,7 @@ class XmiWrapper(Xmi):
 
         if vartype.lower().startswith("double"):
             arraytype = np.ctypeslib.ndpointer(
-                dtype=np.float64, ndim=ndim, shape=shape_tuple, flags="F"
+                dtype=np.float64, ndim=ndim, shape=shape_tuple, flags="C"
             )
             values = arraytype()
             self.execute_function(
@@ -302,7 +302,7 @@ class XmiWrapper(Xmi):
             return values.contents
         elif vartype.lower().startswith("float"):
             arraytype = np.ctypeslib.ndpointer(
-                dtype=np.float32, ndim=ndim, shape=shape_tuple, flags="F"
+                dtype=np.float32, ndim=ndim, shape=shape_tuple, flags="C"
             )
             values = arraytype()
             self.execute_function(
@@ -314,7 +314,7 @@ class XmiWrapper(Xmi):
             return values.contents
         elif vartype.lower().startswith("int"):
             arraytype = np.ctypeslib.ndpointer(
-                dtype=np.int32, ndim=ndim, shape=shape_tuple, flags="F"
+                dtype=np.int32, ndim=ndim, shape=shape_tuple, flags="C"
             )
             values = arraytype()
             self.execute_function(
@@ -329,7 +329,7 @@ class XmiWrapper(Xmi):
         vartype = self.get_var_type(name)
         if vartype.lower().startswith("double"):
             arraytype = np.ctypeslib.ndpointer(
-                dtype=np.double, ndim=1, shape=(1,), flags="F"
+                dtype=np.double, ndim=1, shape=(1,), flags="C"
             )
             values = arraytype()
             self.execute_function(
@@ -340,7 +340,7 @@ class XmiWrapper(Xmi):
             )
         elif vartype.lower().startswith("float"):
             arraytype = np.ctypeslib.ndpointer(
-                dtype=np.float, ndim=1, shape=(1,), flags="F"
+                dtype=np.float, ndim=1, shape=(1,), flags="C"
             )
             values = arraytype()
             self.execute_function(
@@ -351,7 +351,7 @@ class XmiWrapper(Xmi):
             )
         elif vartype.lower().startswith("int"):
             arraytype = np.ctypeslib.ndpointer(
-                dtype=np.int32, ndim=1, shape=(1,), flags="F"
+                dtype=np.int32, ndim=1, shape=(1,), flags="C"
             )
             values = arraytype()
             self.execute_function(
@@ -371,9 +371,8 @@ class XmiWrapper(Xmi):
         raise NotImplementedError
 
     def set_value(self, name: str, values: np.ndarray) -> None:
-        if not values.flags["F"]:
-            raise InputError("Array should have fortran layout")
-
+        if not values.flags["C"]:
+            raise InputError("Array should have C layout")
         vartype = self.get_var_type(name)
         if vartype.lower().startswith("double"):
             if values.dtype != np.float64:


### PR DESCRIPTION
- important: BMI is C-style, numpy arrays (particularly multi-dim) should have that flag!