### PR TITLE
fix typo in get_value

### DIFF
--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -301,7 +301,7 @@ class XmiWrapper(Xmi):
             )
         elif var_type.lower().startswith("int"):
             if dest is None:
-                dest = np.empty(shape=var_shape, dtype=np.int, order="C")
+                dest = np.empty(shape=var_shape, dtype=np.int32, order="C")
             self.execute_function(
                 self.lib.get_value_int,
                 c_char_p(name.encode()),


### PR DESCRIPTION
array dtype should be explicit (linux/macos np.int will be …64bits, on windows it will be 32...), this fixes the problem in PR #57 