### PR TITLE
Set minimum Python version 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ download_url = https://pypi.org/project/xmipy/
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     bmipy
     numpy

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -56,9 +56,6 @@ class XmiWrapper(Xmi):
 
         if lib_dependency:
             self._add_lib_dependency(lib_dependency)
-        if sys.version_info[0:2] < (3, 8):
-            # Python version < 3.8
-            self.lib = CDLL(str(lib_path))
         else:
             # LoadLibraryEx flag: LOAD_WITH_ALTERED_SEARCH_PATH 0x08
             # -> uses the altered search path for resolving dll dependencies

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -56,13 +56,12 @@ class XmiWrapper(Xmi):
 
         if lib_dependency:
             self._add_lib_dependency(lib_dependency)
-        else:
-            # LoadLibraryEx flag: LOAD_WITH_ALTERED_SEARCH_PATH 0x08
-            # -> uses the altered search path for resolving dll dependencies
-            # `winmode` has no effect while running on Linux or macOS
-            # Note: this could make xmipy less secure (dll-injection)
-            # Can we get it to work without this flag?
-            self.lib = CDLL(str(lib_path), winmode=0x08)
+        # LoadLibraryEx flag (py38+): LOAD_WITH_ALTERED_SEARCH_PATH 0x08
+        # -> uses the altered search path for resolving dll dependencies
+        # `winmode` has no effect while running on Linux or macOS
+        # Note: this could make xmipy less secure (dll-injection)
+        # Can we get it to work without this flag?
+        self.lib = CDLL(str(lib_path), winmode=0x08)
 
         if working_directory:
             self.working_directory = Path(working_directory)


### PR DESCRIPTION
As noted [here](https://github.com/MODFLOW-USGS/modflow6/pull/964) and confirmed by myself, the current xmipy version uses features that require a minimum Python 3.8.

Also clean-up some pre-3.8 logic.