### PR TITLE
Remove pymake (mfpymake) dependency, switch to "executables" repo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,8 @@ jobs:
         # This is necessary until proper error reporting is implemented by Modflow
         run: |
           pytest -vs --cov=xmipy --cov-report=xml tests/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
 

--- a/examples/run_advanced.py
+++ b/examples/run_advanced.py
@@ -65,7 +65,6 @@ plt.ylim(bottom=6.0)
 plt.show()
 
 while current_time < end_time:
-
     # modify storage
     # this is done before prepare_timestep because the conversions are done in sto_rp()
     frac = (current_time - start_time) / simulation_length
@@ -83,7 +82,6 @@ while current_time < end_time:
     # loop over subcomponents
     n_solutions = mf6.get_subcomponent_count()
     for sol_id in range(1, n_solutions + 1):
-
         # convergence loop
         kiter = 0
         mf6.prepare_solve(sol_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = [
-    "flopy",
-    "mfpymake",
+    "flopy >=3.3.6",
     "pytest",
     "pytest-cov",
     "requests",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from typing import Any, List, Tuple
 
 import flopy
 import numpy as np
-import pymake
 import pytest
 from flopy.mf6 import MFSimulation
 
@@ -12,21 +11,17 @@ from flopy.mf6 import MFSimulation
 @pytest.fixture(scope="session")
 def modflow_lib_path(tmp_path_factory):
     tmp_path = tmp_path_factory.getbasetemp()
-    url = "https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/latest/download/"
     sysinfo = platform.system()
     if sysinfo == "Windows":
-        url += "win64.zip"
         lib_path = tmp_path / "libmf6.dll"
     elif sysinfo == "Linux":
-        url += "linux.zip"
         lib_path = tmp_path / "libmf6.so"
     elif sysinfo == "Darwin":
-        url += "mac.zip"
         lib_path = tmp_path / "libmf6.dylib"
     else:
         raise RuntimeError(f"system not supported: {sysinfo}")
 
-    pymake.download_and_unzip(url=url, pth=str(tmp_path))
+    flopy.utils.get_modflow(bindir=str(tmp_path))
     return str(lib_path)
 
 

--- a/tests/test_timers.py
+++ b/tests/test_timers.py
@@ -34,7 +34,6 @@ def test_timer_stop_nonexisting_fails():
 
 
 def test_timer_multiple_subtimers():
-
     scope_label_1 = "methodA"
     scope_label_2 = "methodA"
 

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -664,7 +664,6 @@ class XmiWrapper(Xmi):
     def get_var_address(
         self, var_name: str, component_name: str, subcomponent_name=""
     ) -> str:
-
         var_name = var_name.upper()
         component_name = component_name.upper()
         subcomponent_name = subcomponent_name.upper()


### PR DESCRIPTION
This PR changes from https://pypi.org/project/mfpymake/ to flopy>=3.3.6 to get MODFLOw 6 executables. More info on the flopy utility [here](https://flopy.readthedocs.io/en/3.3.6/source/flopy.utils.get_modflow.html).

This PR also changes from fetching executables from the "nightly" repo to the stable "executables" repo. This can be switched later on, but the "nightly" repo [currently has issues](https://github.com/MODFLOW-USGS/modflow6/discussions/1163) with oldish Linux repos, e.g. Ubuntu 20.04.