### PR TITLE
Fix issue with string var with rank 1 and shape [0]

### DIFF
--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -242,13 +242,21 @@ def test_get_var_stringarray(flopy_dis, modflow_lib_path):
         var_nbytes = mf6.get_var_nbytes(bnd_name_tag)
         assert var_nbytes == 2 * 40  # NB: LENBOUNDNAME = 40
 
-        ilen = int(var_nbytes / var_shape[0])
+        ilen = var_nbytes // var_shape[0]
         var_type = mf6.get_var_type(bnd_name_tag)
-        assert var_type == "STRING LEN={} (2)".format(ilen)
+        assert var_type == f"STRING LEN={ilen} (2)"
 
         bnd_names = mf6.get_value(bnd_name_tag)
         assert bnd_names[0] == "BNDA"
         assert bnd_names[1] == "BNDB"
+
+        # test var with rank 1 and shape [0]
+        name_tag = mf6.get_var_address("AUXNAME_CST", flopy_dis.model_name, "CHD_0")
+        assert mf6.get_var_rank(name_tag) == 1
+        assert mf6.get_var_shape(name_tag) == [0]
+        assert mf6.get_var_nbytes(name_tag) == 0
+        assert mf6.get_var_type(name_tag) == "STRING LEN=16 (0)"
+        assert mf6.get_value(name_tag).tolist() == []
 
     finally:
         mf6.finalize()

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -351,7 +351,9 @@ class XmiWrapper(Xmi):
             )
         elif var_type.lower().startswith("string"):
             if dest is None:
-                ilen = int(self.get_var_nbytes(name) / var_shape[0])
+                if var_shape[0] == 0:
+                    return np.empty((0,), "U1")
+                ilen = self.get_var_nbytes(name) // var_shape[0]
                 strtype = "<S" + str(ilen + 1)
                 dest = np.empty(var_shape[0], dtype=strtype, order="C")
             self._execute_function(


### PR DESCRIPTION
This fixes an issue reading a variable with rank 1 and shape [0], e.g. "AUXNAME_CST" or "BOUNDNAME_CST" if these are not defined for the boundary. For instance:
```python
name_tag = mf6.get_var_address("AUXNAME_CST", model_name, "CHD_0")
mf6.get_value(name_tag)
```
would fail with ValueError: cannot convert float NaN to integer

This change returns an empty str array instead.

Another change uses `//` for floor divide instead of `int(a / b)`.