### PR TITLE
Add XmiWrapper.__del__ method to call finalize() if needed

### DIFF
--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -1,6 +1,3 @@
-import math
-import os
-
 import numpy as np
 import pytest
 
@@ -8,672 +5,441 @@ from xmipy import XmiWrapper
 from xmipy.errors import InputError
 
 
-def test_get_component_name(flopy_dis, modflow_lib_path):
+@pytest.fixture
+def flopy_dis_mf6(flopy_dis, modflow_lib_path, request):
     mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-    assert mf6.get_component_name() == "MODFLOW 6"
 
+    # If initialized, call finalize() at end of use
+    request.addfinalizer(mf6.__del__)
 
-def test_set_int(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    # Write output to screen
     mf6.set_int("ISTDOUTTOFILE", 0)
 
+    return flopy_dis, mf6
 
-def test_initialize(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
 
-    # Write output to screen:
+@pytest.fixture
+def flopy_dis_idomain_mf6(flopy_dis_idomain, modflow_lib_path, request):
+    mf6 = XmiWrapper(
+        lib_path=modflow_lib_path, working_directory=flopy_dis_idomain.sim_path
+    )
+
+    # If initialized, call finalize() at end of use
+    request.addfinalizer(mf6.__del__)
+
+    # Write output to screen
     mf6.set_int("ISTDOUTTOFILE", 0)
 
-    try:
-        # Run initialize
+    return flopy_dis_idomain, mf6
+
+
+def test_get_component_name(flopy_dis_mf6):
+    assert flopy_dis_mf6[1].get_component_name() == "MODFLOW 6"
+
+
+def test_initialize_finalize(flopy_dis_mf6):
+    from xmipy.xmiwrapper import State
+
+    mf6 = flopy_dis_mf6[1]
+
+    # Check _state before and after initialize() and finalize()
+    assert mf6._state == State.UNINITIALIZED
+    mf6.initialize()
+    assert mf6._state == State.INITIALIZED
+    mf6.finalize()
+    assert mf6._state == State.UNINITIALIZED
+
+
+def test_double_initialize(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+
+    mf6.initialize()
+
+    # Test if initialize fails, if initialize was called a second time
+    with pytest.raises(InputError, match="library is already initialized"):
         mf6.initialize()
-    finally:
-        mf6.finalize()
 
 
-def test_double_initialize(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-    try:
-        # Run initialize
-        mf6.initialize()
-
-        # Test if initialize fails, if initialize was called a second time
-        with pytest.raises(InputError):
-            mf6.initialize()
-    finally:
-        mf6.finalize()
-
-
-def test_finalize_without_initialize(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+def test_finalize_without_initialize(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
 
     # Test if finalize fails, if initialize was not called yet
-    with pytest.raises(InputError):
+    with pytest.raises(InputError, match="library is not initialized yet"):
         mf6.finalize()
 
 
-def test_get_start_time(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_start_time(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # prescribed_start_time for modflow models is always 0
-        prescribed_start_time = 0.0
-
-        actual_start_time = mf6.get_start_time()
-        assert math.isclose(prescribed_start_time, actual_start_time)
-    finally:
-        mf6.finalize()
+    # prescribed_start_time for modflow models is always 0.0
+    assert mf6.get_start_time() == 0.0
 
 
-def test_get_end_time(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_end_time(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        prescribed_end_time = 0.0
-        for perlen, _, _ in flopy_dis.tdis_rc:
-            prescribed_end_time += perlen
-
-        actual_end_time = mf6.get_end_time()
-        assert math.isclose(prescribed_end_time, actual_end_time)
-    finally:
-        mf6.finalize()
+    assert mf6.get_end_time() == 12.0
 
 
-def test_update(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_update_and_get_current_time(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    assert mf6.get_current_time() == 0.0
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Advance model by single time step
-        mf6.update()
-    finally:
-        mf6.finalize()
+    # Advance model by single time step
+    mf6.update()
+    assert mf6.get_current_time() == 3.0
 
 
-def test_get_current_time(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_var_type_double(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Advance model by single time step
-        mf6.update()
-
-        # prescribed_start_time for modflow models is always 0
-        start_time = 0.0
-
-        perlen, nstp, tsmult = flopy_dis.tdis_rc[0]
-
-        if math.isclose(tsmult, 1):
-            prescribed_current_time = start_time + perlen / nstp
-        else:
-            prescribed_current_time = start_time + perlen * (tsmult - 1.0) / (
-                tsmult**nstp - 1.0
-            )
-
-        actual_current_time = mf6.get_current_time()
-
-        assert math.isclose(prescribed_current_time, actual_current_time)
-    finally:
-        mf6.finalize()
+    head_tag = mf6.get_var_address("X", "SLN_1")
+    assert mf6.get_var_type(head_tag) == "DOUBLE (90)"
 
 
-def test_get_var_type_double(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_var_type_int(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        head_tag = mf6.get_var_address("X", "SLN_1")
-        var_type = mf6.get_var_type(head_tag)
-        assert var_type == "DOUBLE (90)"
-    finally:
-        mf6.finalize()
+    iactive_tag = mf6.get_var_address("IACTIVE", "SLN_1")
+    assert mf6.get_var_type(iactive_tag) == "INTEGER (90)"
 
 
-def test_get_var_type_int(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_var_string(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        iactive_tag = mf6.get_var_address("IACTIVE", "SLN_1")
-        var_type = mf6.get_var_type(iactive_tag)
-        assert var_type == "INTEGER (90)"
-    finally:
-        mf6.finalize()
+    name_tag = mf6.get_var_address("NAME", flopy_dis.model_name)
+    assert mf6.get_var_rank(name_tag) == 0
+    assert mf6.get_var_type(name_tag) == "STRING LEN=16"
+    assert mf6.get_value(name_tag).tolist() == ["TEST_MODEL_DIS"]
 
 
-def test_get_var_string(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_set_var_string(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    name_tag = mf6.get_var_address("NAME", flopy_dis.model_name)
+    assert mf6.get_var_type(name_tag) == "STRING LEN=16"
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        name_tag = mf6.get_var_address("NAME", flopy_dis.model_name)
-        var_type = mf6.get_var_type(name_tag)
-        assert var_type == "STRING LEN=16"
-
-        model_name = mf6.get_value(name_tag)[0]
-        assert model_name == "TEST_MODEL_DIS"
-    finally:
-        mf6.finalize()
+    # this is not yet supported
+    with pytest.raises(InputError, match="Unsupported value type"):
+        mf6.set_value(name_tag, np.array(["VladDeSpietser"]))
 
 
-def test_set_var_string(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_var_stringarray(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    # boundary names are not set until _rp, so we need this update()
+    mf6.update()
 
-    try:
-        # Initialize
-        mf6.initialize()
+    bnd_name_tag = mf6.get_var_address("BOUNDNAME_CST", flopy_dis.model_name, "CHD_0")
+    var_shape = mf6.get_var_shape(bnd_name_tag)
+    assert var_shape == [2]
 
-        name_tag = mf6.get_var_address("NAME", flopy_dis.model_name)
-        var_type = mf6.get_var_type(name_tag)
-        assert var_type == "STRING LEN=16"
+    var_nbytes = mf6.get_var_nbytes(bnd_name_tag)
+    assert var_nbytes == 2 * 40  # NB: LENBOUNDNAME = 40
+    ilen = var_nbytes // var_shape[0]
+    assert mf6.get_var_type(bnd_name_tag) == f"STRING LEN={ilen} (2)"
+    assert mf6.get_value(bnd_name_tag).tolist() == ["BNDA", "BNDB"]
 
-        # this is not yet supported
-        with pytest.raises(InputError):
-            mf6.set_value(name_tag, np.array(["VladDeSpietser"]))
-    finally:
-        mf6.finalize()
-
-
-def test_get_var_stringarray(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # boundary names are not set until _rp, so we need this update()
-        mf6.update()
-
-        bnd_name_tag = mf6.get_var_address(
-            "BOUNDNAME_CST", flopy_dis.model_name, "CHD_0"
-        )
-        var_shape = mf6.get_var_shape(bnd_name_tag)
-        assert var_shape == [2]
-
-        var_nbytes = mf6.get_var_nbytes(bnd_name_tag)
-        assert var_nbytes == 2 * 40  # NB: LENBOUNDNAME = 40
-
-        ilen = var_nbytes // var_shape[0]
-        var_type = mf6.get_var_type(bnd_name_tag)
-        assert var_type == f"STRING LEN={ilen} (2)"
-
-        bnd_names = mf6.get_value(bnd_name_tag)
-        assert bnd_names[0] == "BNDA"
-        assert bnd_names[1] == "BNDB"
-
-        # test var with rank 1 and shape [0]
-        name_tag = mf6.get_var_address("AUXNAME_CST", flopy_dis.model_name, "CHD_0")
-        assert mf6.get_var_rank(name_tag) == 1
-        assert mf6.get_var_shape(name_tag) == [0]
-        assert mf6.get_var_nbytes(name_tag) == 0
-        assert mf6.get_var_type(name_tag) == "STRING LEN=16 (0)"
-        assert mf6.get_value(name_tag).tolist() == []
-
-    finally:
-        mf6.finalize()
+    # test var with rank 1 and shape [0]
+    name_tag = mf6.get_var_address("AUXNAME_CST", flopy_dis.model_name, "CHD_0")
+    assert mf6.get_var_rank(name_tag) == 1
+    assert mf6.get_var_shape(name_tag) == [0]
+    assert mf6.get_var_nbytes(name_tag) == 0
+    assert mf6.get_var_type(name_tag) == "STRING LEN=16 (0)"
+    assert mf6.get_value(name_tag).tolist() == []
 
 
-def test_get_value_ptr_modelname(flopy_dis, modflow_lib_path):
+def test_get_value_ptr_modelname(flopy_dis_mf6):
     """`flopy_dis` sets constant head values.
     This test checks if these can be properly extracted with origin=modelname."""
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    stress_period_data = flopy_dis.stress_period_data
+    shape = flopy_dis.nlay, flopy_dis.nrow, flopy_dis.ncol
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6.update()
+    head_tag = mf6.get_var_address("X", flopy_dis.model_name)
+    actual_head = mf6.get_value_ptr(head_tag)
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        stress_period_data = flopy_dis.stress_period_data
-        ncol = flopy_dis.ncol
-
-        mf6.update()
-        head_tag = mf6.get_var_address("X", flopy_dis.model_name)
-        actual_head = mf6.get_value_ptr(head_tag)
-
-        for cell_id, presciped_head, bn in stress_period_data:
-            layer, row, column = cell_id
-            head_index = column + row * ncol
-            assert math.isclose(presciped_head, actual_head[head_index])
-    finally:
-        mf6.finalize()
+    for cell_id, presciped_head, _ in stress_period_data:
+        head_index = np.ravel_multi_index(cell_id, shape)
+        assert presciped_head == actual_head[head_index]
 
 
-def test_get_value_ptr_scalar(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_value_ptr_scalar(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6.update()
+    id_tag = mf6.get_var_address("ID", flopy_dis.model_name)
+    grid_id = mf6.get_value_ptr_scalar(id_tag)
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        mf6.update()
-        id_tag = mf6.get_var_address("ID", flopy_dis.model_name)
-        grid_id = mf6.get_value_ptr_scalar(id_tag)
-
-        # Only one model is defined => id should be 1
-        # grid_id[0], because even scalars are defined as arrays
-        assert grid_id[0] == 1
-    finally:
-        mf6.finalize()
+    # Only one model is defined => id should be 1
+    # grid_id[0], because even scalars are defined as arrays
+    assert grid_id[0] == 1
 
 
-def test_get_var_grid(flopy_dis, modflow_lib_path):
-    """Tests if the the grid id can be extracted"""
+def test_get_var_grid(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    # Getting the grid id from the model, requires specifying one variable
+    k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
+    prescriped_grid_id = mf6.get_var_grid(k11_tag)
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Getting the grid id from the model, requires specifying one variable
-        k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
-        prescriped_grid_id = mf6.get_var_grid(k11_tag)
-
-        id_tag = mf6.get_var_address("ID", flopy_dis.model_name)
-        actual_grid_id = mf6.get_value_ptr(id_tag)
-
-        assert prescriped_grid_id == actual_grid_id[0]
-    finally:
-        mf6.finalize()
+    id_tag = mf6.get_var_address("ID", flopy_dis.model_name)
+    assert mf6.get_value_ptr(id_tag) == [prescriped_grid_id]
 
 
-def test_get_grid_type(flopy_dis, modflow_lib_path):
+def test_get_grid_type(flopy_dis_mf6):
     """Tests if the grid type can be extracted"""
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Getting the grid id from the model, requires specifying one variable
-        k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
-        grid_id = mf6.get_var_grid(k11_tag)
-        grid_type = mf6.get_grid_type(grid_id)
-
-        assert grid_type == "rectilinear"
-    finally:
-        mf6.finalize()
+    # Getting the grid id from the model, requires specifying one variable
+    k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
+    grid_id = mf6.get_var_grid(k11_tag)
+    assert mf6.get_grid_type(grid_id) == "rectilinear"
 
 
-def test_get_input_item_count(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_input_item_count(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    try:
-        # Initialize
-        mf6.initialize()
-        assert mf6.get_input_item_count() > 0
-
-    finally:
-        mf6.finalize()
+    assert mf6.get_input_item_count() > 0
 
 
-def test_get_output_item_count(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_output_item_count(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    try:
-        # Initialize
-        mf6.initialize()
-        assert mf6.get_output_item_count() > 0
-
-    finally:
-        mf6.finalize()
+    assert mf6.get_output_item_count() > 0
 
 
-def test_get_input_var_names(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_input_var_names(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        var_names = mf6.get_input_var_names()
-        assert "TEST_MODEL_DIS/X" in var_names
-
-    finally:
-        mf6.finalize()
+    assert "TEST_MODEL_DIS/X" in mf6.get_input_var_names()
 
 
-def test_get_output_var_names(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_output_var_names(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        var_names = mf6.get_output_var_names()
-        assert "TEST_MODEL_DIS/X" in var_names  # this is readwrite
-        assert "SLN_1/IA" in var_names  # and this is readonly
-
-    finally:
-        mf6.finalize()
+    var_names = mf6.get_output_var_names()
+    assert "TEST_MODEL_DIS/X" in var_names  # this is readwrite
+    assert "SLN_1/IA" in var_names  # and this is readonly
 
 
-def test_get_var_units(flopy_dis, modflow_lib_path):
+def test_get_var_units(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_var_units` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_var_units("")
 
 
-def test_get_var_location(flopy_dis, modflow_lib_path):
+def test_get_var_location(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_var_location` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_var_location("")
 
 
-def test_get_time_units(flopy_dis, modflow_lib_path):
+def test_get_time_units(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_time_units` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_time_units()
 
 
-def test_get_value_double(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_value_double(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    try:
-        mf6.initialize()
-
-        some_output_var = next(
-            var for var in mf6.get_output_var_names() if var.endswith("/X")
-        )
-        copy_arr = mf6.get_value(some_output_var)
-
-        # compare to array in MODFLOW memory:
-        orig_arr = mf6.get_value_ptr(some_output_var)
-        assert np.array_equal(copy_arr, orig_arr)
-
-    finally:
-        mf6.finalize()
-
-
-def test_get_value_double_inplace(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    try:
-        mf6.initialize()
-
-        some_output_var = next(
-            var for var in mf6.get_output_var_names() if var.endswith("/X")
-        )
-        copy_arr = mf6.get_value_ptr(some_output_var).copy()
-        copy_arr[:] = -99999.0
-        mf6.get_value(some_output_var, copy_arr)
-
-        # compare to array in MODFLOW memory:
-        orig_arr = mf6.get_value_ptr(some_output_var)
-        assert np.array_equal(copy_arr, orig_arr)
-
-    finally:
-        mf6.finalize()
-
-
-def test_get_value_int(flopy_dis_idomain, modflow_lib_path):
-    mf6 = XmiWrapper(
-        lib_path=modflow_lib_path, working_directory=flopy_dis_idomain.sim_path
+    some_output_var = next(
+        var for var in mf6.get_output_var_names() if var.endswith("/X")
     )
 
-    try:
-        mf6.initialize()
-
-        nodes_reduced_tag = next(
-            var for var in mf6.get_output_var_names() if var.endswith("/NODEREDUCED")
-        )
-        tgt_arr = mf6.get_value(nodes_reduced_tag)
-
-        # compare to array in MODFLOW memory:
-        orig_arr = mf6.get_value_ptr(nodes_reduced_tag)
-        assert np.array_equal(tgt_arr, orig_arr)
-
-    finally:
-        mf6.finalize()
-
-
-def test_get_value_int_scalar(flopy_dis_idomain, modflow_lib_path):
-    mf6 = XmiWrapper(
-        lib_path=modflow_lib_path, working_directory=flopy_dis_idomain.sim_path
+    # compare to array in MODFLOW memory:
+    np.testing.assert_array_equal(
+        mf6.get_value(some_output_var),
+        mf6.get_value_ptr(some_output_var),
     )
 
-    try:
-        mf6.initialize()
 
-        # get scalar variable:
-        id_tag = next(var for var in mf6.get_output_var_names() if var.endswith("/ID"))
-        assert mf6.get_var_rank(id_tag) == 0
+def test_get_value_double_inplace(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-        tgt = mf6.get_value(id_tag)
+    some_output_var = next(
+        var for var in mf6.get_output_var_names() if var.endswith("/X")
+    )
+    copy_arr = mf6.get_value_ptr(some_output_var).copy()
+    copy_arr[:] = -99999.0
+    mf6.get_value(some_output_var, copy_arr)
 
-        # compare with value in MODFLOW memory:
-        orig = mf6.get_value_ptr(id_tag)
-        assert np.array_equal(tgt, orig)
+    # compare to array in MODFLOW memory:
+    np.testing.assert_array_equal(
+        copy_arr,
+        mf6.get_value_ptr(some_output_var),
+    )
 
-    finally:
-        mf6.finalize()
+
+def test_get_value_int(flopy_dis_idomain_mf6):
+    mf6 = flopy_dis_idomain_mf6[1]
+    mf6.initialize()
+
+    nodes_reduced_tag = next(
+        var for var in mf6.get_output_var_names() if var.endswith("/NODEREDUCED")
+    )
+
+    # compare to array in MODFLOW memory:
+    np.testing.assert_array_equal(
+        mf6.get_value(nodes_reduced_tag),
+        mf6.get_value_ptr(nodes_reduced_tag),
+    )
 
 
-def test_get_value_at_indices(flopy_dis, modflow_lib_path):
+def test_get_value_int_scalar(flopy_dis_idomain_mf6):
+    mf6 = flopy_dis_idomain_mf6[1]
+    mf6.initialize()
+
+    # get scalar variable:
+    id_tag = next(var for var in mf6.get_output_var_names() if var.endswith("/ID"))
+    assert mf6.get_var_rank(id_tag) == 0
+
+    # compare with value in MODFLOW memory:
+    np.testing.assert_array_equal(
+        mf6.get_value(id_tag),
+        mf6.get_value_ptr(id_tag),
+    )
+
+
+def test_get_value_at_indices(flopy_dis_idomain_mf6):
     """Expects to be implemented as soon as `get_value_at_indices` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_idomain_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_value_at_indices("", np.zeros((1, 1)), np.zeros((1, 1)))
 
 
-def test_set_value(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_set_value(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    try:
-        # Initialize
-        mf6.initialize()
+    # 1D double array
+    head_tag = mf6.get_var_address("X", flopy_dis.model_name)
+    orig_head = mf6.get_value_ptr(head_tag)
+    new_head = 2.0 * orig_head
+    mf6.set_value(head_tag, new_head)
+    np.testing.assert_array_equal(orig_head, new_head)
 
-        # 1D double array
-        head_tag = mf6.get_var_address("X", flopy_dis.model_name)
-        orig_head = mf6.get_value_ptr(head_tag)
-        new_head = 2.0 * orig_head
-        mf6.set_value(head_tag, new_head)
-        assert np.array_equal(orig_head, new_head)
-
-        # 1D integer array
-        mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
-        arr_int = np.zeros(shape=(1,), dtype=np.int32)
-        arr_int[0] = 999
-        mf6.set_value(mxit_tag, arr_int)
-        assert mf6.get_value(mxit_tag)[0] == 999
-
-    finally:
-        mf6.finalize()
+    # 1D integer array
+    mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
+    arr_int = np.zeros(shape=(1,), dtype=np.int32)
+    arr_int[0] = 999
+    mf6.set_value(mxit_tag, arr_int)
+    assert mf6.get_value(mxit_tag).tolist() == [999]
 
 
-def test_set_value_at_indices(flopy_dis, modflow_lib_path):
+def test_set_value_at_indices(flopy_dis_mf6):
     """Expects to be implemented as soon as `set_value_at_indices` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.set_value_at_indices("", np.zeros((1, 1)), np.zeros((1, 1)))
 
 
-def test_get_grid_rank(flopy_dis, modflow_lib_path):
+def test_get_grid_rank(flopy_dis_mf6):
     """Tests if the the grid rank can be extracted"""
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    if flopy_dis.nlay == 1:
+        prescribed_grid_rank = 2
+    else:
+        prescribed_grid_rank = 3
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    # Getting the grid id from the model, requires specifying one variable
+    k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
+    grid_id = mf6.get_var_grid(k11_tag)
 
-    try:
-        mf6.initialize()
-
-        if flopy_dis.nlay == 1:
-            prescribed_grid_rank = 2
-        else:
-            prescribed_grid_rank = 3
-
-        # Getting the grid id from the model, requires specifying one variable
-        k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
-        grid_id = mf6.get_var_grid(k11_tag)
-
-        actual_grid_rank = mf6.get_grid_rank(grid_id)
-
-        assert prescribed_grid_rank == actual_grid_rank
-    finally:
-        mf6.finalize()
+    assert prescribed_grid_rank == mf6.get_grid_rank(grid_id)
 
 
-def test_get_grid_size(flopy_dis, modflow_lib_path):
+def test_get_grid_size(flopy_dis_mf6):
     """Tests if the the grid size can be extracted"""
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    prescribed_grid_size = flopy_dis.nrow * flopy_dis.ncol
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    # Getting the grid id from the model, requires specifying one variable
+    k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
+    grid_id = mf6.get_var_grid(k11_tag)
 
-    try:
-        mf6.initialize()
-
-        prescribed_grid_size = flopy_dis.nrow * flopy_dis.ncol
-
-        # Getting the grid id from the model, requires specifying one variable
-        k11_tag = mf6.get_var_address("K11", flopy_dis.model_name, "NPF")
-        grid_id = mf6.get_var_grid(k11_tag)
-
-        actual_grid_size = mf6.get_grid_size(grid_id)
-
-        assert prescribed_grid_size == actual_grid_size
-    finally:
-        mf6.finalize()
+    assert prescribed_grid_size == mf6.get_grid_size(grid_id)
 
 
-def test_get_grid_spacing(flopy_dis, modflow_lib_path):
+def test_get_grid_spacing(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_grid_spacing` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_grid_spacing(1, np.zeros((1, 1)))
 
 
-def test_get_grid_origin(flopy_dis, modflow_lib_path):
+def test_get_grid_origin(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_grid_origin` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_grid_origin(1, np.zeros((1, 1)))
 
 
-def test_get_grid_edge_count(flopy_dis, modflow_lib_path):
+def test_get_grid_edge_count(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_grid_edge_count` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_grid_edge_count(1)
 
 
-def test_get_grid_edge_nodes(flopy_dis, modflow_lib_path):
+def test_get_grid_edge_nodes(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_grid_edge_nodes` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_grid_edge_nodes(1, np.zeros((1, 1)))
 
 
-def test_get_grid_face_edges(flopy_dis, modflow_lib_path):
+def test_get_grid_face_edges(flopy_dis_mf6):
     """Expects to be implemented as soon as `get_grid_face_edges` is implemented"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
     with pytest.raises(NotImplementedError):
         mf6.get_grid_face_edges(1, np.zeros((1, 1)))

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -92,6 +92,10 @@ class XmiWrapper(Xmi):
                 text="Elapsed time for {name}.{fn_name}: {seconds:0.4f} seconds",
             )
 
+    def __del__(self):
+        if self._state == State.INITIALIZED:
+            self.finalize()
+
     @staticmethod
     def _add_lib_dependency(lib_dependency: Union[str, Path]) -> None:
         lib_dependency = str(lib_dependency)


### PR DESCRIPTION
The main change in this PR is in `xmipy/xmiwrapper.py`, which adds a `XmiWrapper.__del__` method to automatically call `finalize()`, if needed.

This happens whenever Python's garbage collector is invoked, either calling the `del` method or when the variable is out of scope.

This PR also has rewritten and expanded `test_mf6_dis_bmi.py` to adhere to better pytest conventions. The changes are difficult to see, so I'll provide a bullet-point summary of what is done:

- Use a fixture `flopy_dis_mf6` to return `(flopy, dis_mf6)` that has set ISTDOUTTOFILE, and calls `__del__` at end to automatically `.finalize()` instance, if needed. Same idea for `flopy_dis_idomain_mf6`.
- Remove unnecessary try/finally blocks
- Refactor to remove variables that are used once
- Remove tests using `math.isclose` since these instances are expected to be exact (otherwise a better option is [`pytest.approx`](https://docs.pytest.org/en/latest/reference/reference.html#pytest.approx))
- Use [`numpy.testing.assert_array_equal`](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_equal.html) to check arrays
- Combine `test_update` and `test_get_current_time` to `test_update_and_get_current_time`
- Removed some derived expected values with actual expected values, e.g. `assert mf6.get_current_time() == 3.0`

Depending on the feedback from this rewrite, I might consider looking at the other test files too.