### PR TITLE
Revise tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 from flopy.mf6 import MFSimulation
 
+from xmipy import XmiWrapper
+
 
 @pytest.fixture(scope="session")
 def modflow_lib_path(tmp_path_factory):
@@ -79,6 +81,19 @@ def flopy_dis(tmp_path, modflow_lib_path):
     )
     sim.write_simulation()
     return flopy_dis
+
+
+@pytest.fixture
+def flopy_dis_mf6(flopy_dis, modflow_lib_path, request):
+    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+
+    # If initialized, call finalize() at end of use
+    request.addfinalizer(mf6.__del__)
+
+    # Write output to screen
+    mf6.set_int("ISTDOUTTOFILE", 0)
+
+    return flopy_dis, mf6
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -6,19 +6,6 @@ from xmipy.errors import InputError
 
 
 @pytest.fixture
-def flopy_dis_mf6(flopy_dis, modflow_lib_path, request):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # If initialized, call finalize() at end of use
-    request.addfinalizer(mf6.__del__)
-
-    # Write output to screen
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    return flopy_dis, mf6
-
-
-@pytest.fixture
 def flopy_dis_idomain_mf6(flopy_dis_idomain, modflow_lib_path, request):
     mf6 = XmiWrapper(
         lib_path=modflow_lib_path, working_directory=flopy_dis_idomain.sim_path

--- a/tests/test_mf6_dis_errors.py
+++ b/tests/test_mf6_dis_errors.py
@@ -1,47 +1,33 @@
 import pytest
 
-from xmipy import XmiWrapper
 from xmipy.errors import XMIError
 
 
-def test_err_unknown_var(flopy_dis, modflow_lib_path):
+def test_err_unknown_var(flopy_dis_mf6):
     """Unknown or invalid variable address should trigger python Exception,
     print the kernel error, and not crash the library"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    try:
-        # Run initialize
-        mf6.initialize()
+    with pytest.raises(XMIError):
+        mf6.get_var_rank("jnexistepas")
 
-        with pytest.raises(XMIError):
-            mf6.get_var_rank("jnexistepas")
-
-        with pytest.raises(XMIError):
-            var_address = mf6.get_var_address("X", "dissolution")
-            mf6.get_value_ptr(var_address)
-
-    finally:
-        mf6.finalize()
+    with pytest.raises(XMIError):
+        var_address = mf6.get_var_address("X", "dissolution")
+        mf6.get_value_ptr(var_address)
 
 
-def test_err_cvg_failure(flopy_dis, modflow_lib_path):
+def test_err_cvg_failure(flopy_dis_mf6):
     """Test convergence failure (and a helper for checking I/O)"""
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+    # prepare, don't solve to completion, should give error
+    mf6.prepare_time_step(mf6.get_time_step())
+    mf6.prepare_solve()
+    mf6.solve()
 
-    try:
-        # Run initialize
-        mf6.initialize()
+    with pytest.raises(XMIError):
+        mf6.finalize_solve()
 
-        # prepare, don't solve to completion, should give error
-        mf6.prepare_time_step(mf6.get_time_step())
-        mf6.prepare_solve()
-        mf6.solve()
-
-        with pytest.raises(XMIError):
-            mf6.finalize_solve()
-
-        mf6.finalize_time_step()
-
-    finally:
-        mf6.finalize()
+    mf6.finalize_time_step()

--- a/tests/test_mf6_dis_xmi.py
+++ b/tests/test_mf6_dis_xmi.py
@@ -48,7 +48,6 @@ def test_manual_do_time_step(flopy_dis_mf6, sol_id):
     # Prepare solve
     mf6.prepare_solve(*sol_id)
 
-    # mf6.get_var_address("MXITER", "SLN_1")
     max_iter = 25
     for kiter in range(max_iter):
         has_converged = mf6.solve(*sol_id)

--- a/tests/test_mf6_dis_xmi.py
+++ b/tests/test_mf6_dis_xmi.py
@@ -1,213 +1,68 @@
-from xmipy import XmiWrapper
+import pytest
 
 
-def test_get_var_address(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_var_address(flopy_dis_mf6):
+    flopy_dis, mf6 = flopy_dis_mf6
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    head_tag = mf6.get_var_address("X", "SLN_1")
+    assert head_tag == "SLN_1/X"
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        head_tag = mf6.get_var_address("X", "SLN_1")
-        assert head_tag == "SLN_1/X"
-
-        # with lowercase should work too
-        k11_tag = mf6.get_var_address("k11", flopy_dis.model_name.lower(), "NPF")
-        assert k11_tag == flopy_dis.model_name.upper() + "/NPF/K11"
-    finally:
-        mf6.finalize()
+    # with lowercase should work too
+    k11_tag = mf6.get_var_address("k11", flopy_dis.model_name.lower(), "NPF")
+    assert k11_tag == flopy_dis.model_name.upper() + "/NPF/K11"
 
 
-def test_prepare_time_step(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_prepare_time_step(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        dt = mf6.get_time_step()
-        mf6.prepare_time_step(dt)
-    finally:
-        mf6.finalize()
+    dt = mf6.get_time_step()
+    assert dt == 0.0
+    mf6.prepare_time_step(dt)
+    assert mf6.get_time_step() == 3.0
 
 
-def test_get_subcomponent_count(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_subcomponent_count(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        n_solutions = mf6.get_subcomponent_count()
-
-        # Modflow 6 BMI does only support the use of a single solution groups
-        assert n_solutions == 1
-    finally:
-        mf6.finalize()
+    # Modflow 6 BMI does only support the use of a single solution groups
+    assert mf6.get_subcomponent_count() == 1
 
 
-def test_prepare_solve(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+@pytest.mark.parametrize("sol_id", [(1,), ()])
+def test_manual_do_time_step(flopy_dis_mf6, sol_id):
+    """Test four xmi functions:
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+        - prepare_solve
+        - solve
+        - finalize_solve
+        - finalize_time_step
 
-    try:
-        # Initialize
-        mf6.initialize()
+    Parameterized using a component_id (sol_id) or default for XmiWrapper.
+    """
+    mf6 = flopy_dis_mf6[1]
+    mf6.initialize()
 
-        # Prepare solve
-        sol_id = 1
-        mf6.prepare_solve(sol_id)
-    finally:
-        mf6.finalize()
+    # Prepare solve
+    mf6.prepare_solve(*sol_id)
 
+    # mf6.get_var_address("MXITER", "SLN_1")
+    max_iter = 25
+    for kiter in range(max_iter):
+        has_converged = mf6.solve(*sol_id)
 
-def test_solve(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+        if has_converged:
+            break
 
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
+    assert has_converged
 
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Prepare solve
-        sol_id = 1
-        mf6.prepare_solve(sol_id)
-
-        # Get max iteration
-        mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
-        max_iter_arr = mf6.get_value_ptr(mxit_tag)
-        max_iter = max_iter_arr[0]
-
-        kiter = 0
-        while kiter < max_iter:
-            has_converged = mf6.solve(sol_id)
-            kiter += 1
-
-            if has_converged:
-                break
-
-        assert has_converged
-    finally:
-        mf6.finalize()
+    mf6.finalize_solve(*sol_id)
+    mf6.finalize_time_step()
 
 
-def test_finalize_solve(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Prepare solve
-        sol_id = 1
-        mf6.prepare_solve(sol_id)
-
-        # Get max iteration
-        mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
-        max_iter_arr = mf6.get_value_ptr(mxit_tag)
-        max_iter = max_iter_arr[0]
-
-        kiter = 0
-        while kiter < max_iter:
-            has_converged = mf6.solve(sol_id)
-            kiter += 1
-
-            if has_converged:
-                break
-
-        assert has_converged
-        mf6.finalize_solve(sol_id)
-    finally:
-        mf6.finalize()
-
-
-def test_solve_default_solution_id(flopy_dis, modflow_lib_path):
-    """Should no longer be needed to put in the solution id,
-    when there is only one (or you want to use the first one
-    in the sequence"""
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        #
-        mf6.prepare_solve()
-
-        # Get max iteration
-        mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
-        max_iter_arr = mf6.get_value_ptr(mxit_tag)
-        max_iter = max_iter_arr[0]
-
-        kiter = 0
-        while kiter < max_iter:
-            has_converged = mf6.solve()
-            kiter += 1
-
-            if has_converged:
-                break
-
-        assert has_converged
-
-        mf6.finalize_solve()
-    finally:
-        mf6.finalize()
-
-
-def test_finalize_time_step(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
-
-    # Write output to screen:
-    mf6.set_int("ISTDOUTTOFILE", 0)
-
-    try:
-        # Initialize
-        mf6.initialize()
-
-        # Prepare solve
-        sol_id = 1
-        mf6.prepare_solve(sol_id)
-
-        # Get max iteration
-        mxit_tag = mf6.get_var_address("MXITER", "SLN_1")
-        max_iter_arr = mf6.get_value_ptr(mxit_tag)
-        max_iter = max_iter_arr[0]
-
-        kiter = 0
-        while kiter < max_iter:
-            has_converged = mf6.solve(sol_id)
-            kiter += 1
-
-            if has_converged:
-                break
-
-        assert has_converged
-        mf6.finalize_solve(sol_id)
-        mf6.finalize_time_step()
-    finally:
-        mf6.finalize()
-
-
-def test_get_version(flopy_dis, modflow_lib_path):
-    mf6 = XmiWrapper(lib_path=modflow_lib_path, working_directory=flopy_dis.sim_path)
+def test_get_version(flopy_dis_mf6):
+    mf6 = flopy_dis_mf6[1]
 
     assert len(mf6.get_version()) > 0

--- a/tests/test_mf6_disu_bmi.py
+++ b/tests/test_mf6_disu_bmi.py
@@ -19,22 +19,20 @@ def flopy_disu_mf6(flopy_disu, modflow_lib_path, request):
 
 def test_get_grid_face_count(flopy_disu_mf6):
     """Tests if the grid_face_count can be extracted"""
-    mf6 = flopy_disu_mf6[1]
+    flopy_disu, mf6 = flopy_disu_mf6
     mf6.initialize()
 
-    nrow = 3
-    ncol = 3
-    assert nrow * ncol == mf6.get_grid_face_count(1)
+    expected_grid_face_count = flopy_disu.nrow * flopy_disu.ncol
+    assert expected_grid_face_count == mf6.get_grid_face_count(1)
 
 
 def test_get_grid_node_count(flopy_disu_mf6):
     """Tests if the grid_node_count can be extracted"""
-    mf6 = flopy_disu_mf6[1]
+    flopy_disu, mf6 = flopy_disu_mf6
     mf6.initialize()
 
-    nrow = 3
-    ncol = 3
-    assert (nrow + 1) * (ncol + 1) == mf6.get_grid_node_count(1)
+    expected_grid_node_count = (flopy_disu.nrow + 1) * (flopy_disu.ncol + 1)
+    assert expected_grid_node_count == mf6.get_grid_node_count(1)
 
 
 def test_get_grid_nodes_per_face(flopy_disu_mf6):

--- a/tests/test_timers.py
+++ b/tests/test_timers.py
@@ -14,8 +14,8 @@ def test_timer_create_and_run():
     time.sleep(0.1)
     timer.stop(scope_label)
 
-    value = timer.report_totals()
-    assert value > 0.09
+    # the timing +/- result is platform dependant
+    assert timer.report_totals() >= 0.09
 
 
 def test_timer_start_twice_fails():
@@ -23,13 +23,13 @@ def test_timer_start_twice_fails():
     timer = Timer("aTimer", "Some text with details")
     timer.start(scope_label)
 
-    with pytest.raises(TimerError):
+    with pytest.raises(TimerError, match="Timer for theMethod is already running"):
         timer.start(scope_label)
 
 
 def test_timer_stop_nonexisting_fails():
     timer = Timer("aTimer", "Some text with details")
-    with pytest.raises(TimerError):
+    with pytest.raises(TimerError, match="Timer for imnotthere is not running"):
         timer.stop("imnotthere")
 
 
@@ -47,5 +47,4 @@ def test_timer_multiple_subtimers():
     time.sleep(0.1)
     timer.stop(scope_label_2)
 
-    value = timer.report_totals()
-    assert value > 0.019
+    assert timer.report_totals() > 0.019


### PR DESCRIPTION
This caries on efforts from #87 to rewrite tests, making them more compact to see/review.

- Move `flopy_dis_mf6` fixture to "global" `tests/conftest.py`, as the scope of this should be used in multiple files
- Use a `flopy_dis_mf6_timing` fixture just for timing tests (i.e. it has `timing=True`)
- Add `test_manual_do_time_step` to cover `prepare_solve`, `solve`, `finalize_solve`, and `finalize_time_step` using specified `sol_id` or default parameters; this replaces other individual tests
- Mark `test_get_grid_face_nodes` with [xfail](https://docs.pytest.org/en/7.1.x/how-to/skipping.html), as this appears to be work-in-progress
- Remove array order for flat arrays, as this is misleading (array order is only relevant for multidimensional arrays)
- Add an assert to see if return object from `get_grid_nodes_per_face` is the same object as the input array