### PR TITLE
Add a logger to XmiWrapper

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,106 @@
+import logging
+import os.path
+
+import xmipy.logger
+from xmipy import XmiWrapper
+
+
+def test_logger_defaults(caplog, modflow_lib_path):
+    mf6 = XmiWrapper(modflow_lib_path)
+
+    assert mf6.logger.level == logging.NOTSET
+    assert mf6.logger.name == os.path.basename(modflow_lib_path)
+
+    mf6.logger.debug("not shown")
+    assert len(caplog.record_tuples) == 0
+
+    mf6.logger.info("also not shown")
+    assert len(caplog.record_tuples) == 0
+
+    mf6.logger.warning("warnings or higher are shown")
+    assert len(caplog.record_tuples) == 1
+    assert "warnings or higher are shown" in caplog.text
+
+
+def test_logger_level(caplog, modflow_lib_path):
+    mf6 = XmiWrapper(modflow_lib_path, logger_level="INFO")
+
+    assert mf6.logger.level == logging.INFO
+
+    mf6.logger.debug("not shown")
+    assert len(caplog.record_tuples) == 0
+
+    mf6.logger.info("this is shown")
+    assert len(caplog.record_tuples) == 1
+    assert "this is shown" in caplog.text
+
+
+def test_show_logger_message(caplog, modflow_lib_path):
+    mf6 = XmiWrapper(modflow_lib_path)
+
+    with xmipy.logger.show_logger_message(mf6.logger):
+        mf6.logger.debug("debug not shown")
+        assert len(caplog.record_tuples) == 0
+
+        mf6.logger.info("info now shown")
+        assert len(caplog.record_tuples) == 1
+        assert "info now shown" in caplog.text
+
+    caplog.clear()
+
+    mf6.logger.info("info not shown")
+    assert len(caplog.record_tuples) == 0
+
+
+def test_show_logger_message_lower_level(caplog, modflow_lib_path):
+    mf6 = XmiWrapper(modflow_lib_path)
+
+    mf6.logger.debug("debug not shown")
+    assert len(caplog.record_tuples) == 0
+
+    with xmipy.logger.show_logger_message(mf6.logger, logging.DEBUG):
+        mf6.logger.debug("debug shown")
+        assert len(caplog.record_tuples) == 1
+        assert "debug shown" in caplog.text
+
+    caplog.clear()
+
+    mf6.logger.debug("debug not shown")
+    assert len(caplog.record_tuples) == 0
+
+    caplog.clear()
+
+    # Use ignore_disabled=True which does not change outcome
+    with xmipy.logger.show_logger_message(mf6.logger, logging.DEBUG, True):
+        mf6.logger.debug("debug still shown")
+        assert len(caplog.record_tuples) == 1
+        assert "debug still shown" in caplog.text
+
+
+def test_show_disabled_logger_message(caplog, modflow_lib_path):
+    mf6 = XmiWrapper(modflow_lib_path)
+
+    mf6.logger.disabled = True
+
+    mf6.logger.warning("no warning")
+    assert len(caplog.record_tuples) == 0
+
+    # Use default ignore_disabled=False to never show messages
+    with xmipy.logger.show_logger_message(mf6.logger, logging.WARNING):
+        mf6.logger.info("info not shown")
+        assert len(caplog.record_tuples) == 0
+
+        mf6.logger.warning("warning not shown")
+        assert len(caplog.record_tuples) == 0
+
+    mf6.logger.critical("nothing critical")
+    assert len(caplog.record_tuples) == 0
+
+    # Use ignore_disabled=True to sometimes show messages
+    with xmipy.logger.show_logger_message(mf6.logger, ignore_disabled=True):
+        mf6.logger.debug("debug not shown")
+        assert len(caplog.record_tuples) == 0
+
+        mf6.logger.info("info shown")
+        assert len(caplog.record_tuples) == 1
+        assert "info shown" in caplog.text

--- a/xmipy/logger.py
+++ b/xmipy/logger.py
@@ -1,0 +1,67 @@
+"""Logger module."""
+
+__all__ = ["get_logger", "show_logger_message"]
+
+import logging
+import sys
+from logging import Logger
+from contextlib import contextmanager
+from typing import Union
+
+
+def get_logger(name: str, level: Union[str, int] = 0):
+    """Return a named logger.
+
+    Parameters
+    ----------
+    name : str
+        Logger name.
+    logger_level : str, int, optional
+        Logger level, default 0 ("NOTSET"). Accepted values are
+        "DEBUG" (10), "INFO" (20), "WARNING" (30), "ERROR" (40) or
+        "CRITICAL" (50).
+
+    Returns
+    -------
+    Logger
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    if not logger.hasHandlers():
+        formatter = logging.Formatter("%(name)s:%(levelname)s: %(message)s")
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    return logger
+
+
+@contextmanager
+def show_logger_message(
+    logger: Logger, level: int = logging.INFO, ignore_disabled: bool = False
+):
+    """Context manager to show logger messages at and above a given level.
+
+    Parameters
+    ----------
+    logger : Logger
+        Logger instance.
+    level : int, optional
+        Logger level threshold to show messages, default 20 ("INFO").
+    ignore_disabled : bool, default False
+        If True, disabled loggers may still emit messages. If False (default),
+        disabled loggers never emit messages.
+    """
+    not_enabled = not logger.isEnabledFor(level)
+    if not_enabled:
+        prev_level = logger.level
+        logger.setLevel(level)
+    toggle_disabled = logger.disabled and ignore_disabled
+    if toggle_disabled:
+        logger.disabled = False
+    yield
+    if not_enabled:
+        logger.setLevel(prev_level)
+    if toggle_disabled:
+        logger.disabled = True


### PR DESCRIPTION
This adds a `logger` to `XmiWrapper`, which can be used internally/externally to trace messages. It is based on the [Python `logging` module](https://docs.python.org/3/library/logging.html). It replaces a generic logger in `xmipy.xmiwrapper`.

The new module `xmipy.logger` has two methods:

- `get_logger` - used to create or retrieve a named logger
- `show_logger_message` - used to always show message at a different logger level, regardless if the logger is disabled

The constructor for `XmiWrapper` is modified to add `logger_level` with default 0 or NOTSET, which (usually?) shows messages from `.warning`, `.error` and `.critical`, not not from `.debug` or `.info`. The new attribute looks something like this:
```python
from xmipy import XmiWrapper

mf6 = XmiWrapper("/tmp/py310/bin/libmf6.so")

mf6.logger.debug("details")
# nothing shown

mf6.logger.warning("oh no!")
# libmf6.so:WARNING: oh no!

# change levels to show debug info
mf6.logger.setLevel("DEBUG")
mf6.logger.debug("details")
# libmf6.so:DEBUG: details
```
Internally, this logger is only used twice in this PR:

1. `report_timing_totals` previously used the generic logger's `.info` which wouldn't have shown anything. Now it shows:
    ```
    >>> mf6.report_timing_totals()
    # libmf6.so:INFO: Total elapsed time for libmf6.so: 0.0490 seconds
    0.049019320984371006
    ```
    progress? It shows both a formatted logger message and returns a float.
2. `_execute_function` previously used the generic logger's `.warn` (which raised "DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead"), which is replaced with `.error` which is more appropriate for the situation (I think).

The logger module can be used internally more. I have considered using it more in `xmipy.timers`, but I'm not sure how at the moment.

---

Another footnote is anyone familiar with the Open Earth version of BMI in C/Fortran/Python may recall it had similar logging features, for example see [`set_logger`](https://github.com/openearth/bmi-python/blob/c07d892ff87215c8a3399c05b93e5b492b6ae6bc/bmi/wrapper.py#L691) with the same [named logger levels](https://github.com/openearth/bmi-python/blob/c07d892ff87215c8a3399c05b93e5b492b6ae6bc/bmi/wrapper.py#L64-L71). Not sure if a similar `set_logger` should be used for XmiWrapper or not.

There are some logger-related things in `imod_coupler` too (e.g. [here](https://github.com/search?q=repo%3ADeltares%2Fimod_coupler%20LogLevel&type=code)), so again, not sure how the strategy could/should be used by dependent tools.