### PR TITLE
Add more logger messages; add repr_function_call()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def test_pretty_ctypes_execute_function():
+    from ctypes import (
+        POINTER,
+        byref,
+        c_char,
+        c_char_p,
+        c_double,
+        c_float,
+        c_void_p,
+        create_string_buffer,
+        pointer,
+    )
+
+    from xmipy.utils import pretty_ctypes_execute_function
+
+    ar = np.zeros(2, dtype=np.int32)
+    sar = np.zeros(1, dtype="<S4")
+    far = np.zeros(shape=(2, 3), dtype="<f8", order="C")
+    arraytype = np.ctypeslib.ndpointer(dtype="<f8", ndim=2, shape=(2, 3), flags="C")
+
+    cases = [
+        ("x()", []),
+        ("x(b'')", ["".encode()]),
+        ("x(b'z', 5)", ["z".encode(), 5]),
+        ("x(c_double(1.0))", [c_double(1)]),
+        ("x(&c_double(8.0))", [byref(c_double(8))]),
+        ("x(*c_double(9.0))", [pointer(c_double(9))]),
+        ("x(c_char_Array_5(b''))", [create_string_buffer(5)]),
+        ("x(c_char_Array_2(b'z'))", [create_string_buffer("z".encode())]),
+        ("x(&c_char_Array_5(b''))", [byref(create_string_buffer(5))]),
+        ("x(&c_char_Array_2(b'z'))", [byref(create_string_buffer(b"z"))]),
+        ("x(c_char_p(b'z'))", [c_char_p("z".encode())]),
+        ("x(&c_char_p(b'z'))", [byref(c_char_p("z".encode()))]),
+        (f"x(c_void_p({ar.ctypes.data}))", [c_void_p(ar.ctypes.data)]),
+        (r"x(*c_char(b'\x00'))", [sar.ctypes.data_as(POINTER(c_char))]),
+        (r"x(&*c_char(b'\x00'))", [byref(sar.ctypes.data_as(POINTER(c_char)))]),
+        ("x(*c_float(0.0))", [far.ctypes.data_as(POINTER(c_float))]),
+        ("x(&*c_float(0.0))", [byref(far.ctypes.data_as(POINTER(c_float)))]),
+        ("x(ndpointer_<f8_2d_2x3_C)", [arraytype()]),
+        ("x(&ndpointer_<f8_2d_2x3_C)", [byref(arraytype())]),
+    ]
+    for expected, args in cases:
+        assert expected == pretty_ctypes_execute_function("x", *args)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def test_pretty_ctypes_execute_function():
+def test_repr_function_call():
     from ctypes import (
         POINTER,
         byref,
@@ -14,7 +14,7 @@ def test_pretty_ctypes_execute_function():
         pointer,
     )
 
-    from xmipy.utils import pretty_ctypes_execute_function
+    from xmipy.utils import repr_function_call
 
     ar = np.zeros(2, dtype=np.int32)
     sar = np.zeros(1, dtype="<S4")
@@ -43,4 +43,4 @@ def test_pretty_ctypes_execute_function():
         ("x(&ndpointer_<f8_2d_2x3_C)", [byref(arraytype())]),
     ]
     for expected, args in cases:
-        assert expected == pretty_ctypes_execute_function("x", *args)
+        assert expected == repr_function_call("x", *args)

--- a/xmipy/logger.py
+++ b/xmipy/logger.py
@@ -29,7 +29,7 @@ def get_logger(name: str, level: Union[str, int] = 0):
     logger.setLevel(level)
 
     if not logger.hasHandlers():
-        formatter = logging.Formatter("%(name)s:%(levelname)s: %(message)s")
+        formatter = logging.Formatter("%(levelname)s:%(name)s: %(message)s")
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(formatter)
         logger.addHandler(handler)

--- a/xmipy/utils.py
+++ b/xmipy/utils.py
@@ -16,10 +16,18 @@ def cd(newdir: Path):
         os.chdir(prevdir)
 
 
-def pretty_ctypes_execute_function(function: str, *args):
-    """Return a descriptive ctypes function call."""
+def repr_function_call(function: str, *args) -> str:
+    """Return a descriptive ctypes function call.
 
-    def format_item(arg):
+    Parameters
+    ----------
+    function : str
+        Name of function.
+    *args : tuple
+        Zero or more arguments, usally based on ctypes.
+    """
+
+    def format_arg(arg) -> str:
         if isinstance(arg, (ctypes.Array, ctypes.c_char_p)):
             return f"{arg.__class__.__name__}({arg.value!r})"
         elif isinstance(arg, np.ctypeslib._ndptr):
@@ -35,8 +43,8 @@ def pretty_ctypes_execute_function(function: str, *args):
     for arg in args:
         if hasattr(arg, "_obj"):
             # Format byref() with "&" prefix
-            item = "&" + format_item(arg._obj)
+            item = "&" + format_arg(arg._obj)
         else:
-            item = format_item(arg)
+            item = format_arg(arg)
         items.append(item)
     return f"{function}({', '.join(items)})"

--- a/xmipy/utils.py
+++ b/xmipy/utils.py
@@ -1,6 +1,9 @@
 import os
 from contextlib import contextmanager
 from pathlib import Path
+import ctypes
+
+import numpy as np
 
 
 @contextmanager
@@ -11,3 +14,29 @@ def cd(newdir: Path):
         yield
     finally:
         os.chdir(prevdir)
+
+
+def pretty_ctypes_execute_function(function: str, *args):
+    """Return a descriptive ctypes function call."""
+
+    def format_item(arg):
+        if isinstance(arg, (ctypes.Array, ctypes.c_char_p)):
+            return f"{arg.__class__.__name__}({arg.value!r})"
+        elif isinstance(arg, np.ctypeslib._ndptr):
+            return arg.__class__.__name__
+        elif isinstance(arg, ctypes._Pointer):
+            return "*" + repr(arg.contents)
+        elif isinstance(arg, ctypes._SimpleCData):
+            return repr(arg)
+        else:
+            return repr(arg)
+
+    items = []
+    for arg in args:
+        if hasattr(arg, "_obj"):
+            # Format byref() with "&" prefix
+            item = "&" + format_item(arg._obj)
+        else:
+            item = format_item(arg)
+        items.append(item)
+    return f"{function}({', '.join(items)})"

--- a/xmipy/xmiwrapper.py
+++ b/xmipy/xmiwrapper.py
@@ -22,7 +22,7 @@ from numpy.typing import NDArray
 from xmipy.errors import InputError, TimerError, XMIError
 from xmipy.logger import get_logger, show_logger_message
 from xmipy.timers.timer import Timer
-from xmipy.utils import cd, pretty_ctypes_execute_function
+from xmipy.utils import cd, repr_function_call
 from xmipy.xmi import Xmi
 
 
@@ -253,7 +253,6 @@ class XmiWrapper(Xmi):
             self.lib.get_var_grid,
             c_char_p(name.encode()),
             byref(grid_id),
-            detail="for variable " + name,
         )
         return grid_id.value
 
@@ -264,7 +263,6 @@ class XmiWrapper(Xmi):
             self.lib.get_var_type,
             c_char_p(name.encode()),
             byref(var_type),
-            detail="for variable " + name,
         )
         return var_type.value.decode()
 
@@ -276,7 +274,6 @@ class XmiWrapper(Xmi):
             self.lib.get_var_shape,
             c_char_p(name.encode()),
             c_void_p(array.ctypes.data),
-            detail="for variable " + name,
         )
         return array
 
@@ -286,7 +283,6 @@ class XmiWrapper(Xmi):
             self.lib.get_var_rank,
             c_char_p(name.encode()),
             byref(rank),
-            detail="for variable " + name,
         )
         return rank.value
 
@@ -299,7 +295,6 @@ class XmiWrapper(Xmi):
             self.lib.get_var_itemsize,
             c_char_p(name.encode()),
             byref(item_size),
-            detail="for variable " + name,
         )
         return item_size.value
 
@@ -309,7 +304,6 @@ class XmiWrapper(Xmi):
             self.lib.get_var_nbytes,
             c_char_p(name.encode()),
             byref(nbytes),
-            detail="for variable " + name,
         )
         return nbytes.value
 
@@ -340,7 +334,6 @@ class XmiWrapper(Xmi):
                     self.lib.get_value_string,
                     c_char_p(name.encode()),
                     byref(dest.ctypes.data_as(POINTER(c_char))),
-                    detail="for variable " + name,
                 )
                 dest[0] = dest[0].decode("ascii").strip()
                 return dest.astype(str)
@@ -361,7 +354,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_double,
                 c_char_p(name.encode()),
                 byref(dest.ctypes.data_as(POINTER(c_double))),
-                detail="for variable " + name,
             )
         elif var_type_lower.startswith("int"):
             if dest is None:
@@ -370,7 +362,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_int,
                 c_char_p(name.encode()),
                 byref(dest.ctypes.data_as(POINTER(c_int))),
-                detail="for variable " + name,
             )
         elif var_type_lower.startswith("string"):
             if dest is None:
@@ -383,7 +374,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_string,
                 c_char_p(name.encode()),
                 byref(dest.ctypes.data_as(POINTER(c_char))),
-                detail="for variable " + name,
             )
             for i, x in enumerate(dest):
                 dest[i] = x.decode("ascii").strip()
@@ -416,7 +406,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_ptr_double,
                 c_char_p(name.encode()),
                 byref(values),
-                detail="for variable " + name,
             )
             return values.contents
         elif var_type_lower.startswith("float"):
@@ -428,7 +417,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_ptr_float,
                 c_char_p(name.encode()),
                 byref(values),
-                detail="for variable " + name,
             )
             return values.contents
         elif var_type_lower.startswith("int"):
@@ -440,7 +428,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_ptr_int,
                 c_char_p(name.encode()),
                 byref(values),
-                detail="for variable " + name,
             )
             return values.contents
         else:
@@ -458,7 +445,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_ptr_double,
                 c_char_p(name.encode()),
                 byref(values),
-                detail="for variable " + name,
             )
         elif var_type_lower.startswith("float"):
             arraytype = np.ctypeslib.ndpointer(
@@ -469,7 +455,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_ptr_float,
                 c_char_p(name.encode()),
                 byref(values),
-                detail="for variable " + name,
             )
         elif var_type_lower.startswith("int"):
             arraytype = np.ctypeslib.ndpointer(
@@ -480,7 +465,6 @@ class XmiWrapper(Xmi):
                 self.lib.get_value_ptr_int,
                 c_char_p(name.encode()),
                 byref(values),
-                detail="for variable " + name,
             )
         else:
             raise InputError(f"Unsupported value type {var_type!r}")
@@ -502,7 +486,6 @@ class XmiWrapper(Xmi):
                 self.lib.set_value_double,
                 c_char_p(name.encode()),
                 byref(values.ctypes.data_as(POINTER(c_double))),
-                detail="for variable " + name,
             )
         elif var_type_lower.startswith("int"):
             if values.dtype != np.int32:
@@ -511,7 +494,6 @@ class XmiWrapper(Xmi):
                 self.lib.set_value_int,
                 c_char_p(name.encode()),
                 byref(values.ctypes.data_as(POINTER(c_int))),
-                detail="for variable " + name,
             )
         else:
             raise InputError("Unsupported value type")
@@ -526,7 +508,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_rank,
             byref(c_grid),
             byref(grid_rank),
-            detail="for id " + str(grid),
         )
         return grid_rank.value
 
@@ -537,7 +518,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_size,
             byref(c_grid),
             byref(grid_size),
-            detail="for id " + str(grid),
         )
         return grid_size.value
 
@@ -549,7 +529,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_type,
             byref(c_grid),
             byref(grid_type),
-            detail="for id " + str(grid),
         )
         return grid_type.value.decode()
 
@@ -559,7 +538,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_shape,
             byref(c_grid),
             c_void_p(shape.ctypes.data),
-            detail="for id " + str(grid),
         )
         return shape
 
@@ -575,7 +553,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_x,
             byref(c_grid),
             c_void_p(x.ctypes.data),
-            detail="for id " + str(grid),
         )
         return x
 
@@ -585,7 +562,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_y,
             byref(c_grid),
             c_void_p(y.ctypes.data),
-            detail="for id " + str(grid),
         )
         return y
 
@@ -595,7 +571,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_z,
             byref(c_grid),
             c_void_p(z.ctypes.data),
-            detail="for id " + str(grid),
         )
         return z
 
@@ -606,7 +581,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_node_count,
             byref(c_grid),
             byref(grid_node_count),
-            detail="for id " + str(grid),
         )
         return grid_node_count.value
 
@@ -620,7 +594,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_face_count,
             byref(c_grid),
             byref(grid_face_count),
-            detail="for id " + str(grid),
         )
         return grid_face_count.value
 
@@ -636,7 +609,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_face_nodes,
             byref(c_grid),
             c_void_p(face_nodes.ctypes.data),
-            detail="for id " + str(grid),
         )
         return face_nodes
 
@@ -646,7 +618,6 @@ class XmiWrapper(Xmi):
             self.lib.get_grid_nodes_per_face,
             byref(c_grid),
             c_void_p(nodes_per_face.ctypes.data),
-            detail="for id " + str(grid),
         )
         return nodes_per_face
 
@@ -704,9 +675,7 @@ class XmiWrapper(Xmi):
 
         return var_address.value.decode()
 
-    def _execute_function(
-        self, function: Callable[[Any], int], *args, detail=""
-    ) -> None:
+    def _execute_function(self, function: Callable[[Any], int], *args) -> None:
         """
         Utility function to execute a BMI function in the kernel and checks its status
         """
@@ -721,13 +690,13 @@ class XmiWrapper(Xmi):
             if self.logger.isEnabledFor(logging.DEBUG):
                 self.logger.debug(
                     "execute function: %s returned %s",
-                    pretty_ctypes_execute_function(function.__name__, *args),
+                    repr_function_call(function.__name__, *args),
                     result,
                 )
 
             if result != Status.SUCCESS:
                 msg = "BMI exception in "
-                msg += pretty_ctypes_execute_function(function.__name__, *args)
+                msg += repr_function_call(function.__name__, *args)
 
                 # try to get detailed error msg, beware:
                 # directly call CDLL methods to avoid recursion


### PR DESCRIPTION
This is a follow on from #101 to make more use of the logger.

- Adds `xmipy.utils.repr_function_call` to somewhat translate ctypes calls into something readable-ish. It isn't prefect, but it's a start to debugging library calls.
- Rearrange the logger message to `"%(levelname)s:%(name)s: %(message)s"`
- Replace "vartype" with "var_type" for more consistency
- Show var_type in InputError messages
- Use `np.float64` in place of `np.double` (it is an alias)
- Fix bug with `get_value_ptr_scalar`, using `np.float32` instead of `float` (which is double precision, not single precision)

The new logger info is only shown with "DEBUG" levels. Here is what it looks like:
```
In [1]: from xmipy import XmiWrapper

In [2]: mf6 = XmiWrapper("/path/to/libmf6.so", working_directory="/path/to/sim", logger_level="DEBUG")

In [3]: mf6.initialize()
DEBUG:libmf6.so: execute function: initialize(b'') returned 0

In [4]: mf6.get_start_time()
DEBUG:libmf6.so: execute function: get_start_time(&c_double(0.0)) returned 0
Out[4]: 0.0

In [5]: mf6.get_end_time()
DEBUG:libmf6.so: execute function: get_end_time(&c_double(504.0)) returned 0
Out[5]: 504.0

In [6]: mf6.get_grid_rank(1)
DEBUG:libmf6.so: execute function: get_grid_rank(&c_int(1), &c_int(2)) returned 0
Out[6]: 2

In [7]: mf6.get_value('SLN_1/MXITER')
DEBUG:libmf6.so: execute function: get_var_rank(c_char_p(b'SLN_1/MXITER'), &c_int(0)) returned 0
DEBUG:libmf6.so: execute function: get_var_type(c_char_p(b'SLN_1/MXITER'), &c_char_Array_51(b'INTEGER')) returned 0
DEBUG:libmf6.so: execute function: get_var_type(c_char_p(b'SLN_1/MXITER'), &c_char_Array_51(b'INTEGER')) returned 0
DEBUG:libmf6.so: execute function: get_value_ptr_int(c_char_p(b'SLN_1/MXITER'), &ndpointer_<i4_1d_1_C) returned 0
DEBUG:libmf6.so: execute function: get_var_type(c_char_p(b'SLN_1/MXITER'), &c_char_Array_51(b'INTEGER')) returned 0
DEBUG:libmf6.so: execute function: get_value_ptr_int(c_char_p(b'SLN_1/MXITER'), &ndpointer_<i4_1d_1_C) returned 0
Out[7]: array([25], dtype=int32)
```
Note that "detail" in `_execute_function` is not used anymore and could be cleaned up, since it normally had something like `"for variable " + name` which is obvious to see from the debug messages. Let me know if it should be clean up or not.