### PR TITLE
Test with modflow6 release and nightly, add test.common module

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        modflow6-repo: [modflow6, modflow6-nightly-build]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,14 +27,16 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - name: Setup Fortran
         uses: fortran-lang/setup-fortran@v1
+      - name: Install MODFLOW 6
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: ${{ matrix.modflow6-repo }}
       - name: Install test dependencies
         run: |
           pip install -e ".[tests]"
-      - name: Test with pytest
-        # The flag -s stops pytest from capturing output
-        # This is necessary until proper error reporting is implemented by Modflow
+      - name: Run tests with MODFLOW 6 release
         run: |
-          pytest -vs --cov=xmipy --cov-report=xml tests/
+          pytest -v --cov=xmipy --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ docs = ["pdoc"]
 Documentation = "https://deltares.github.io/xmipy/xmipy.html"
 Source = "https://github.com/Deltares/xmipy"
 
+[tool.hatch.build.targets.wheel]
+packages = ["xmipy"]
+
 [tool.hatch.version]
 path = "xmipy/__init__.py"
 
@@ -49,6 +52,9 @@ disallow_incomplete_defs = true
 disallow_untyped_defs = true
 no_implicit_reexport = true
 warn_return_any = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 select = [

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,45 @@
+"""Common functions for tests. For pytest fixtures, see conftest.py."""
+
+import os
+import platform
+import shutil
+from pathlib import Path
+
+
+def get_libmf6() -> Path:
+    """Get libmf6 based on environment variable or PATH with mf6.
+
+    To specify directly, set the environment variable `LIBMF6` to the path of
+    the library to test.
+
+    Otherwise, check for the environment variable `MODFLOW_BIN_PATH` as used by
+    modflowpy/install-modflow-action to find the mf6 executable.
+
+    Lastly, find the mf6 executable from the PATH environment, and
+    try to find the library in the same directory as the executable.
+    """
+    if "LIBMF6" in os.environ:
+        lib_path = Path(os.environ["LIBMF6"])
+    else:
+        if "MODFLOW_BIN_PATH" in os.environ:
+            mf6 = shutil.which("mf6", path=os.environ["MODFLOW_BIN_PATH"])
+        else:
+            mf6 = shutil.which("mf6")
+        if mf6 is None:
+            raise FileNotFoundError("cannot find mf6 on PATH")
+        mf6 = Path(mf6)
+        sysinfo = platform.system()
+        if sysinfo == "Windows":
+            lib_path = mf6.parent / "libmf6.dll"
+        elif sysinfo == "Linux":
+            lib_path = mf6.parent / "libmf6.so"
+        elif sysinfo == "Darwin":
+            lib_path = mf6.parent / "libmf6.dylib"
+        else:
+            raise NotImplementedError(f"system not supported: {sysinfo}")
+    if lib_path.exists():
+        return lib_path
+    raise FileNotFoundError(f"{lib_path} not found")
+
+
+libmf6_path = get_libmf6()

--- a/tests/common.py
+++ b/tests/common.py
@@ -21,8 +21,8 @@ def get_libmf6() -> Path:
     if "LIBMF6" in os.environ:
         lib_path = Path(os.environ["LIBMF6"])
     else:
-        if "MODFLOW_BIN_PATH" in os.environ:
-            mf6 = shutil.which("mf6", path=os.environ["MODFLOW_BIN_PATH"])
+        if modflow_bin_path := os.environ.get("MODFLOW_BIN_PATH"):
+            mf6 = shutil.which("mf6", path=modflow_bin_path)
         else:
             mf6 = shutil.which("mf6")
         if mf6 is None:


### PR DESCRIPTION
There are a number of changes related to tests:

- Add `tests/common.py` for common test functions that are not fixtures (these are kept at `conftest.py`). Note that `tests` is now a module, but it is not included by setuptools for installation/packaging.
- Move logic that determines libmf6 for tests from `conftest.modflow_lib_path` to `common.libmf6_path`, based on:
  1.  An environment variable `LIBMF6` for the direct path to the `.so`/`.dll`/`.dylib` file
  2.  An environment variable `MODFLOW_BIN_PATH` to the directory with both `mf6` and `libmf6` (the suffix is determined by platform); this is the default path used by [modflowpy/install-modflow-action](https://github.com/modflowpy/install-modflow-action#path)
  3. Evaluated on the system PATH, assuming that `libmf6` is in the same directory as `mf6`
 - Show path for libmf6 in the pytest report header
 - Modify CI tests to install from the modflow6 release repo, run tests
 - <s>Re-install modflow6 from the nightly build repo, an re-run tests, amending coverage reports</s>
 - Parameterize modflow nightly build repo to test matrix
 - Change pytest invocation by removing `s` option that disable all capturing. This change is done since the capturing by pytest seems to be usually adequate to debug issues (perhaps this wasn't the case before?)
 
<s>The other key change is to only run `test_err_cvg_failure` for libmf6 versions before modflow-6.4.2. (I'll admit that I don't fully understand this change, but this seems to be a deliberate change).</s>

Closes #106