### PR TITLE
Use hatchling and ruff format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,20 +23,8 @@ jobs:
           pip install ruff
       - name: Run Ruff
         run: ruff check .
-  black:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install black
-      - name: Run black
-        run: black --check .
+      - name: Run Ruff format
+        run: ruff format --check .
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "xmipy"
@@ -24,21 +24,15 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = ["flopy >=3.3.6", "pytest", "pytest-cov", "requests"]
-lint = ["black", "ruff", "mypy"]
+lint = ["ruff", "mypy"]
 docs = ["pdoc"]
-
-[tool.setuptools]
-zip-safe = false
-
-[tool.setuptools.dynamic]
-version = { attr = "xmipy.__version__" }
-
-[tool.setuptools.package-data]
-"xmipy" = ["py.typed"]
 
 [project.urls]
 Documentation = "https://deltares.github.io/xmipy/xmipy.html"
 Source = "https://github.com/Deltares/xmipy"
+
+[tool.hatch.version]
+path = "xmipy/__init__.py"
 
 [tool.mypy]
 exclude = ["tests"]


### PR DESCRIPTION
Hatchling replaces setuptools and lets IDEs work with editable installs Ruff format is a faster black