### PR TITLE
Refactor tests, adding a common module

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         pixi-environment: ["py39", "py310", "py311", "py312"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        modflow6-repo: [modflow6, modflow6-nightly-build]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Pixi
@@ -32,7 +33,7 @@ jobs:
       - name: Install MODFLOW 6
         uses: modflowpy/install-modflow-action@v1
         with:
-          repo: modflow6
+          repo: ${{ matrix.modflow6-repo }}
       - name: Test with pytest
         run: pixi run tests-ci
         env: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,8 @@ jobs:
           manifest-path: pyproject.toml
       - name: Install MODFLOW 6
         uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6
       - name: Test with pytest
         run: pixi run tests-ci
         env: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,14 +16,13 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.pixi-environment }} - ${{ matrix.os }} - ${{ matrix.modflow6-repo }}
+    name: ${{ matrix.pixi-environment }} - ${{ matrix.os }}
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
       matrix:
         pixi-environment: ["py39", "py310", "py311", "py312"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        modflow6-repo: [modflow6, modflow6-nightly-build]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Pixi
@@ -33,7 +32,7 @@ jobs:
       - name: Install MODFLOW 6
         uses: modflowpy/install-modflow-action@v1
         with:
-          repo: ${{ matrix.modflow6-repo }}
+          repo: modflow6-nightly-build
       - name: Test with pytest
         run: pixi run tests-ci
         env: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.pixi-environment }} - ${{ matrix.os }}
+    name: ${{ matrix.pixi-environment }} - ${{ matrix.os }} - ${{ matrix.modflow6-repo }}
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.6.0
         with:
           manifest-path: pyproject.toml
+      - name: Install MODFLOW 6
+        uses: modflowpy/install-modflow-action@v1
       - name: Test with pytest
         run: pixi run tests-ci
         env: 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,8 +1,10 @@
-version: 4
+version: 5
 environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -490,6 +492,8 @@ environments:
   py310:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -978,6 +982,8 @@ environments:
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1465,6 +1471,8 @@ environments:
   py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1952,6 +1960,8 @@ environments:
   py39:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2494,79 +2504,19 @@ packages:
   url: https://files.pythonhosted.org/packages/07/fe/d7b94a17094f646491b27f43b0259a7916597e544fbcfd6bb638a823e29d/black-24.4.0-cp312-cp312-macosx_11_0_arm64.whl
   sha256: 4396ca365a4310beef84d446ca5016f671b10f07abdba3e4e4304218d2c71d33
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/42/d3/8fa632ab059f2a79f8dd2e2910d245b045bca847373a9017c442e206df49/black-24.4.0-cp312-cp312-macosx_10_9_x86_64.whl
-  sha256: f95cece33329dc4aa3b0e1a771c41075812e46cf3d6e3f1dfe3d91ff09826ed2
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/0f/ce/28131fefb3bd6197ab2d1841e869e9b6abe90b54080ac29ccb504433263b/black-24.4.0-cp312-cp312-win_amd64.whl
-  sha256: 21f9407063ec71c5580b8ad975653c66508d6a9f57bd008bb8691d273705adcd
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/57/bc/c7f2e1665805b79476c4f10b554d0f8659b5f19f49d86eb5ef6c876f15ba/black-24.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 44d99dfdf37a2a00a6f7a8dcbd19edf361d056ee51093b2445de7ca09adac965
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
@@ -2574,19 +2524,19 @@ packages:
   url: https://files.pythonhosted.org/packages/0a/ef/37666bae20ba77d9a8420867077879fc0fd26e60e734ba5ee5ebc46f72fb/black-24.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 5cd5b4f76056cecce3e69b0d4c228326d2595f506797f40b9233424e2524c070
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
@@ -2594,59 +2544,39 @@ packages:
   url: https://files.pythonhosted.org/packages/0f/11/fa05ac9429d971d0fc10da85f24dafc3fa5788733fbd0d1c186b7577cefd/black-24.4.0-cp311-cp311-win_amd64.whl
   sha256: 64578cf99b6b46a6301bc28bdb89f9d6f9b592b1c5837818a177c98525dbe397
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
   version: 24.4.0
-  url: https://files.pythonhosted.org/packages/cb/95/4a02a0fed559bf638001f6bf4e4c9d685111db959d221485e7e27c91e954/black-24.4.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 8e5537f456a22cf5cfcb2707803431d2feeb82ab3748ade280d6ccd0b40ed2e8
+  url: https://files.pythonhosted.org/packages/0f/ce/28131fefb3bd6197ab2d1841e869e9b6abe90b54080ac29ccb504433263b/black-24.4.0-cp312-cp312-win_amd64.whl
+  sha256: 21f9407063ec71c5580b8ad975653c66508d6a9f57bd008bb8691d273705adcd
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/97/a6/f5857f79bba7eca05ebdc7e27e3447e3d2fc23898bb04f34bf3ff5dfb2db/black-24.4.0-cp311-cp311-macosx_11_0_arm64.whl
-  sha256: 64e60a7edd71fd542a10a9643bf369bfd2644de95ec71e86790b063aa02ff745
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
@@ -2654,139 +2584,19 @@ packages:
   url: https://files.pythonhosted.org/packages/28/3e/92c4b155420aa9722996ae4fb0b857cea856a701630014283b348c4e9504/black-24.4.0-cp310-cp310-macosx_10_9_x86_64.whl
   sha256: 6ad001a9ddd9b8dfd1b434d566be39b1cd502802c8d38bbb1ba612afda2ef436
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/91/a0/df4cae0a28c5b32bbef232b81ece9556f96c0d4aeaccdc202b9882d9698b/black-24.4.0-cp310-cp310-macosx_11_0_arm64.whl
-  sha256: e3a3a092b8b756c643fe45f4624dbd5a389f770a4ac294cf4d0fce6af86addaf
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/99/f7/bd2b367aa8833d532451d943ecc0deb7f846f872477bfa8deaa04e86373b/black-24.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: dae79397f367ac8d7adb6c779813328f6d690943f64b32983e896bcccd18cbad
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/d5/41/9c3d8ec509cfb35b646c00cb912d769f9a92aa5e469401d90b80314d209f/black-24.4.0-cp310-cp310-win_amd64.whl
-  sha256: 71d998b73c957444fb7c52096c3843875f4b6b47a54972598741fe9a7f737fcb
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/6c/b0/6dd1ad928d28b52d8f931e94ad94f5ac302dca984cc5aefa616143d8ebdb/black-24.4.0-cp39-cp39-macosx_10_9_x86_64.whl
-  sha256: 6644f97a7ef6f401a150cca551a1ff97e03c25d8519ee0bbc9b0058772882665
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/ef/32/5e59d4aeec3db4964404939ae7d3d9e839df7c882cd50296f3cfcb4738c5/black-24.4.0-cp39-cp39-win_amd64.whl
-  sha256: 7852b05d02b5b9a8c893ab95863ef8986e4dda29af80bbbda94d7aee1abf8702
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.0
-  url: https://files.pythonhosted.org/packages/a3/bb/b1054dce88a6405329890a9006b355eb133845da8dcc62e6c88f9a55435b/black-24.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: eb949f56a63c5e134dfdca12091e98ffb5fd446293ebae123d10fc1abad00b9e
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
@@ -2794,19 +2604,219 @@ packages:
   url: https://files.pythonhosted.org/packages/42/c6/1fe1d87c212a91164c7ab35e98350167667da039ce5f92552c7c3e36d0df/black-24.4.0-cp39-cp39-macosx_11_0_arm64.whl
   sha256: 75a2d0b4f5eb81f7eebc31f788f9830a6ce10a68c91fbe0fade34fff7a2836e6
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/42/d3/8fa632ab059f2a79f8dd2e2910d245b045bca847373a9017c442e206df49/black-24.4.0-cp312-cp312-macosx_10_9_x86_64.whl
+  sha256: f95cece33329dc4aa3b0e1a771c41075812e46cf3d6e3f1dfe3d91ff09826ed2
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/57/bc/c7f2e1665805b79476c4f10b554d0f8659b5f19f49d86eb5ef6c876f15ba/black-24.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 44d99dfdf37a2a00a6f7a8dcbd19edf361d056ee51093b2445de7ca09adac965
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/6c/b0/6dd1ad928d28b52d8f931e94ad94f5ac302dca984cc5aefa616143d8ebdb/black-24.4.0-cp39-cp39-macosx_10_9_x86_64.whl
+  sha256: 6644f97a7ef6f401a150cca551a1ff97e03c25d8519ee0bbc9b0058772882665
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/91/a0/df4cae0a28c5b32bbef232b81ece9556f96c0d4aeaccdc202b9882d9698b/black-24.4.0-cp310-cp310-macosx_11_0_arm64.whl
+  sha256: e3a3a092b8b756c643fe45f4624dbd5a389f770a4ac294cf4d0fce6af86addaf
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/97/a6/f5857f79bba7eca05ebdc7e27e3447e3d2fc23898bb04f34bf3ff5dfb2db/black-24.4.0-cp311-cp311-macosx_11_0_arm64.whl
+  sha256: 64e60a7edd71fd542a10a9643bf369bfd2644de95ec71e86790b063aa02ff745
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/99/f7/bd2b367aa8833d532451d943ecc0deb7f846f872477bfa8deaa04e86373b/black-24.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: dae79397f367ac8d7adb6c779813328f6d690943f64b32983e896bcccd18cbad
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/a3/bb/b1054dce88a6405329890a9006b355eb133845da8dcc62e6c88f9a55435b/black-24.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: eb949f56a63c5e134dfdca12091e98ffb5fd446293ebae123d10fc1abad00b9e
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/cb/95/4a02a0fed559bf638001f6bf4e4c9d685111db959d221485e7e27c91e954/black-24.4.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 8e5537f456a22cf5cfcb2707803431d2feeb82ab3748ade280d6ccd0b40ed2e8
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/d5/41/9c3d8ec509cfb35b646c00cb912d769f9a92aa5e469401d90b80314d209f/black-24.4.0-cp310-cp310-win_amd64.whl
+  sha256: 71d998b73c957444fb7c52096c3843875f4b6b47a54972598741fe9a7f737fcb
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.0
+  url: https://files.pythonhosted.org/packages/ef/32/5e59d4aeec3db4964404939ae7d3d9e839df7c882cd50296f3cfcb4738c5/black-24.4.0-cp39-cp39-win_amd64.whl
+  sha256: 7852b05d02b5b9a8c893ab95863ef8986e4dda29af80bbbda94d7aee1abf8702
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_full_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp>=3.7.4,!=3.9.0 ; implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'
+  - aiohttp>=3.7.4 ; (implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: bmipy
@@ -3794,7 +3804,7 @@ packages:
   sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   requires_dist:
   - colorama ; platform_system == 'Windows'
-  - importlib-metadata ; python_version < '3.8'
+  - importlib-metadata ; python_full_version < '3.8'
   requires_python: '>=3.7'
 - kind: conda
   name: cmarkgfm
@@ -10628,15 +10638,15 @@ packages:
   url: https://files.pythonhosted.org/packages/55/72/4898c44ee9ea6f43396fbc23d9bfaf3d06e01b83698bdf2e4c919deceb7c/platformdirs-4.2.0-py3-none-any.whl
   sha256: 0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068
   requires_dist:
-  - furo >=2023.9.10 ; extra == 'docs'
-  - proselint >=0.13 ; extra == 'docs'
-  - sphinx-autodoc-typehints >=1.25.2 ; extra == 'docs'
-  - sphinx >=7.2.6 ; extra == 'docs'
-  - appdirs ==1.4.4 ; extra == 'test'
-  - covdefaults >=2.3 ; extra == 'test'
-  - pytest-cov >=4.1 ; extra == 'test'
-  - pytest-mock >=3.12 ; extra == 'test'
-  - pytest >=7.4.3 ; extra == 'test'
+  - furo>=2023.9.10 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - appdirs==1.4.4 ; extra == 'test'
+  - covdefaults>=2.3 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
+  - pytest-mock>=3.12 ; extra == 'test'
+  - pytest>=7.4.3 ; extra == 'test'
   requires_python: '>=3.8'
 - kind: conda
   name: pluggy
@@ -12915,16 +12925,16 @@ packages:
   timestamp: 1667051294134
 - kind: pypi
   name: xmipy
-  version: 1.4.0
+  version: 1.5.0
   path: .
-  sha256: 0d6a5bff8a8d979b01c8a94dce87ee8b6161fbaa6147615ae18f8498237afe0d
+  sha256: 65f685f0744f869687a292d6c3f96b3f1e6a818f78c3f8fa38fc14d7597f8ba7
   requires_dist:
   - bmipy
   - numpy
   - pdoc ; extra == 'docs'
   - mypy ; extra == 'lint'
   - ruff ; extra == 'lint'
-  - flopy >=3.3.6 ; extra == 'tests'
+  - flopy>=3.3.6 ; extra == 'tests'
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   - requests ; extra == 'tests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ docs = ["pdoc"]
 Documentation = "https://deltares.github.io/xmipy/xmipy.html"
 Source = "https://github.com/Deltares/xmipy"
 
+[tool.hatch.build.targets.wheel]
+packages = ["xmipy"]
+
 [tool.hatch.version]
 path = "xmipy/__init__.py"
 
@@ -56,8 +59,8 @@ twine = "*"
 # Tests
 # The flag -s stops pytest from capturing output
 # This is necessary until proper error reporting is implemented by Modflow
-tests-ci = "pytest -vs --cov=xmipy --cov-report=xml tests/"
-tests = "pytest tests/"
+tests-ci = "pytest --cov=xmipy --cov-report=xml"
+tests = "pytest"
 
 # Docs
 docs = "pdoc -o docs/ xmipy"
@@ -90,6 +93,10 @@ py311 = ["py311"]
 py310 = ["py310"]
 py39 = ["py39"]
 
+[tool.pytest.ini_options]
+addopts = "-vs"
+testpaths = ["tests"]
+
 [tool.mypy]
 exclude = ["tests"]
 warn_unused_configs = true
@@ -106,7 +113,7 @@ disallow_untyped_defs = true
 no_implicit_reexport = true
 warn_return_any = true
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "ARG",
     "B",

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,45 @@
+"""Common functions for tests. For pytest fixtures, see conftest.py."""
+
+import os
+import platform
+import shutil
+from pathlib import Path
+
+
+def get_libmf6() -> Path:
+    """Get libmf6 based on environment variable or PATH with mf6.
+
+    To specify directly, set the environment variable `LIBMF6` to the path of
+    the library to test.
+
+    Otherwise, check for the environment variable `MODFLOW_BIN_PATH` as used by
+    modflowpy/install-modflow-action to find the mf6 executable.
+
+    Lastly, find the mf6 executable from the PATH environment, and
+    try to find the library in the same directory as the executable.
+    """
+    if "LIBMF6" in os.environ:
+        lib_path = Path(os.environ["LIBMF6"])
+    else:
+        if modflow_bin_path := os.environ.get("MODFLOW_BIN_PATH"):
+            mf6 = shutil.which("mf6", path=modflow_bin_path)
+        else:
+            mf6 = shutil.which("mf6")
+        if mf6 is None:
+            raise FileNotFoundError("cannot find mf6 on PATH")
+        mf6 = Path(mf6)
+        sysinfo = platform.system()
+        if sysinfo == "Windows":
+            lib_path = mf6.parent / "libmf6.dll"
+        elif sysinfo == "Linux":
+            lib_path = mf6.parent / "libmf6.so"
+        elif sysinfo == "Darwin":
+            lib_path = mf6.parent / "libmf6.dylib"
+        else:
+            raise NotImplementedError(f"system not supported: {sysinfo}")
+    if lib_path.exists():
+        return lib_path
+    raise FileNotFoundError(f"{lib_path} not found")
+
+
+libmf6_path = get_libmf6()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-import platform
+"""Fixtures for pytest. Other common functions are in common.py."""
+
 from dataclasses import dataclass
 from typing import Any, List, Tuple
 
@@ -9,22 +10,19 @@ from flopy.mf6 import MFSimulation
 
 from xmipy import XmiWrapper
 
+from .common import libmf6_path
+
+
+def pytest_report_header(**kwargs):  # noqa: ARG001
+    """Show report header at top of pytest output.
+    https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_report_header
+    """
+    return f"libmf6: {libmf6_path}"
+
 
 @pytest.fixture(scope="session")
-def modflow_lib_path(tmp_path_factory):
-    tmp_path = tmp_path_factory.getbasetemp()
-    sysinfo = platform.system()
-    if sysinfo == "Windows":
-        lib_path = tmp_path / "libmf6.dll"
-    elif sysinfo == "Linux":
-        lib_path = tmp_path / "libmf6.so"
-    elif sysinfo == "Darwin":
-        lib_path = tmp_path / "libmf6.dylib"
-    else:
-        raise RuntimeError(f"system not supported: {sysinfo}")
-
-    flopy.utils.get_modflow(bindir=str(tmp_path), repo="modflow6-nightly-build")
-    return str(lib_path)
+def modflow_lib_path():
+    return libmf6_path
 
 
 @dataclass
@@ -167,6 +165,15 @@ def flopy_disu(tmp_path):
     flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=2, perioddata=flopy_disu.tdis_rc)
     flopy.mf6.ModflowIms(sim)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=flopy_disu.model_name, save_flows=True)
+    # fmt: off
+    ja = [0, 1, 3, 1, 0, 2, 4, 2, 1, 5, 3, 0, 4, 6, 4, 1, 3,
+          5, 7, 5, 2, 4, 8, 6, 3, 7, 7, 4, 6, 8, 8, 5, 7]
+    # fmt: on
+    zero_locs = [0, 3, 7, 10, 14, 19, 23, 26, 30]
+    hwva = np.full(33, 1.0)
+    hwva[zero_locs] = 0.0
+    cl12 = np.full(33, 0.5)
+    cl12[zero_locs] = 0.0
     flopy.mf6.ModflowGwfdisu(
         gwf,
         nodes=9,
@@ -176,112 +183,10 @@ def flopy_disu(tmp_path):
         bot=[-2.0],
         area=np.full(9, 1.0),
         iac=[3, 4, 3, 4, 5, 4, 3, 4, 3],
-        ja=[
-            0,
-            1,
-            3,
-            1,
-            0,
-            2,
-            4,
-            2,
-            1,
-            5,
-            3,
-            0,
-            4,
-            6,
-            4,
-            1,
-            3,
-            5,
-            7,
-            5,
-            2,
-            4,
-            8,
-            6,
-            3,
-            7,
-            7,
-            4,
-            6,
-            8,
-            8,
-            5,
-            7,
-        ],
+        ja=ja,
         ihc=[1],
-        cl12=[
-            0,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-            0.5,
-            0,
-            0.5,
-            0.5,
-        ],
-        hwva=[
-            0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-            1.0,
-            0,
-            1.0,
-            1.0,
-        ],
+        cl12=cl12,
+        hwva=hwva,
         vertices=[
             [0, 0.0, 0.0],
             [1, 0.0, 1.0],

--- a/tests/test_mf6_dis_bmi.py
+++ b/tests/test_mf6_dis_bmi.py
@@ -299,7 +299,7 @@ def test_get_value_int_scalar(flopy_dis_idomain_mf6):
     mf6.initialize()
 
     # get scalar variable:
-    id_tag = next(var for var in mf6.get_output_var_names() if var.endswith("/ID"))
+    id_tag = next(var for var in mf6.get_output_var_names() if var.endswith("/NROW"))
     assert mf6.get_var_rank(id_tag) == 0
 
     # compare with value in MODFLOW memory:


### PR DESCRIPTION
This PR simplifies a few ambitions of #108 to:

- Add `tests/common.py` for common test functions that are not fixtures (these are kept at `conftest.py`). Note that `tests` is now a module, but it is not included by hatch for installation/packaging.
- Move logic that determines libmf6 for tests from `conftest.modflow_lib_path` to `common.libmf6_path`, based on:
  1.  An environment variable `LIBMF6` for the direct path to the `.so`/`.dll`/`.dylib` file
  2.  An environment variable `MODFLOW_BIN_PATH` to the directory with both `mf6` and `libmf6` (the suffix is determined by platform); this is the default path used by [modflowpy/install-modflow-action](https://github.com/modflowpy/install-modflow-action#path)
  3. Evaluated on the system PATH, assuming that `libmf6` is in the same directory as `mf6`
 - Install MODFLOW 6 using https://github.com/modflowpy/install-modflow-action
 - Show path for libmf6 in the pytest report header
 - Move common pytest settings to `[tool.pytest.ini_options]` in `pyproject.toml`
 - Fix a Ruff check warning that the top-level linter settings are deprecated
 - Compact white space used with data used in `flopy_disu` fixture.