### PR TITLE
Apply PEP 639 to improve license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,9 @@ authors = [
     { name = "Joseph D. Hughes", email = "jdhughes@usgs.gov" },
 ]
 keywords = ["BMI", "Basic Model Interface"]
-license = { text = "CC0" }
+license = "CC0-1.0"
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
This applies [PEP 639](https://peps.python.org/pep-0639/) to improved license metadata:

- Change license to a text attribute with a valid SPDX identifier [`CC0-1.0`](https://spdx.org/licenses/CC0-1.0.html); the table syntax is deprecated
- Remove licence classifier, which is also deprecated